### PR TITLE
Adding a "dlib" (for digital library) module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val dlibDependencies = Seq(
     ws,
     cache,
     "commons-io" % "commons-io" % "2.4",
+    "org.json" % "json" % "20151123",
     "org.scalatestplus" %% "play" % "1.2.0" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -80,6 +80,13 @@ lazy val dlDependencies = Seq(
     "org.scalatestplus" %% "play" % "1.2.0" % "test"
 )
 
+lazy val dlibDependencies = Seq(
+    ws,
+    cache,
+    "commons-io" % "commons-io" % "2.4",
+    "org.scalatestplus" %% "play" % "1.2.0" % "test"
+)
+
 lazy val webDependencies = Seq(
     ws,
     cache,
@@ -214,6 +221,17 @@ lazy val dl = (project in file("modules/deeplearn"))
     .settings(EclipseKeys.skipParents in ThisBuild := false)
     .aggregate(api, ml)
     .dependsOn(api, ml)
+
+lazy val dlib = (project in file("modules/dlib"))
+    .enablePlugins(PlayScala)
+    .settings(name := "Tuktu-dlib")
+    .settings(version := "1.0")
+    .settings(scalaVersion := "2.11.7")
+    .settings(resolvers ++= appResolvers)
+    .settings(libraryDependencies ++= dlibDependencies)
+    .settings(EclipseKeys.skipParents in ThisBuild := false)
+    .aggregate(api)
+    .dependsOn(api)
     
 lazy val web = (project in file("modules/web"))
     .enablePlugins(PlayScala)
@@ -279,5 +297,5 @@ lazy val root = project
     .settings(resolvers ++= appResolvers)
     .settings(libraryDependencies ++= coreDependencies)
     .settings(EclipseKeys.skipParents in ThisBuild := false)
-    .aggregate(api, nlp, csv, dfs, dl, social, nosql, ml, web, tuktudb, crawler, modeller, viz)
-    .dependsOn(api, nlp, csv, dfs, dl, social, nosql, ml, web, tuktudb, crawler, modeller, viz)
+    .aggregate(api, nlp, csv, dfs, dl, social, nosql, ml, web, tuktudb, crawler, modeller, viz, dlib)
+    .dependsOn(api, nlp, csv, dfs, dl, social, nosql, ml, web, tuktudb, crawler, modeller, viz, dlib)

--- a/modules/dlib/LICENSE
+++ b/modules/dlib/LICENSE
@@ -1,0 +1,8 @@
+This software is licensed under the Apache 2 license, quoted below.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with
+the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/modules/dlib/app/tuktu/dlib/generators/europeanaGenerators.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/europeanaGenerators.scala
@@ -1,0 +1,104 @@
+package tuktu.dlib.generators
+
+import akka.actor._
+import akka.pattern.ask
+import java.util.concurrent.atomic.AtomicInteger
+import play.api.libs.concurrent.Akka
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import play.api.Logger
+import play.api.Play.current
+import scala.concurrent.ExecutionContext.Implicits.global
+import tuktu.api._
+import scala.io.Source
+import scala.io.Codec
+
+case class LinksPacket( links: Seq[String] )
+
+
+/**
+ * Actor that queries the Europeana API
+ */
+class EuropeanaActor(parentActor: ActorRef, query: String, apikey: String, maxresult: Option[Int]) extends Actor with ActorLogging 
+{
+    var total: Int = _
+    
+    def receive() = 
+    {   
+        case ip: InitPacket => 
+        {
+            total = 0
+            self ! LinksPacket( callEuropeana( query, 0 ) )
+        }
+        case stop: StopPacket => 
+        {
+            // stop
+            parentActor ! new StopPacket
+            self ! PoisonPill
+        }
+        case lpacket: LinksPacket => 
+        {
+            // Send back to parent for pushing into channel
+            parentActor ! lpacket.links.head
+
+            // Continue with remaining links if any
+            lpacket.links.tail.isEmpty match {
+              case true => self ! new StopPacket
+              case false => self ! LinksPacket( lpacket.links.tail )
+            }
+        }
+    }
+    
+    def callEuropeana( query: String, start: Int ): Stream[String] =
+    {
+        val encoding: String = "UTF8"
+        val src: Source = Source.fromURL( query + "&start=" + (start + 1) + "&wskey=" + apikey )( Codec.apply( encoding ) )
+        val json = Json.parse( src.mkString )
+        src.close()
+        val itemsCount: Int = (json \ "itemsCount").as[Int]
+        val tr: Int = (json \ "totalResults").as[Int]
+        val totalResults: Int = maxresult match{
+          case None => tr
+          case Some(max) => if ((max < tr) && (max > 0)) max else tr
+        } 
+        val results: Stream[String] = (json \ "items").as[Stream[JsObject]].map{ x => (x \ "link").as[String] }
+        total = total + itemsCount
+        if (totalResults > total)
+        {
+            return results ++ callEuropeana( query, total )
+        }
+        else
+        {
+            return results
+        }       
+    }
+    
+}
+
+
+/**
+ * Queries the Europeana API and returns pointers to the resulting records.
+ */
+class EuropeanaGenerator( resultName: String, processors: List[Enumeratee[DataPacket, DataPacket]], senderActor: Option[ActorRef] ) 
+    extends BaseGenerator(resultName, processors, senderActor) 
+{
+    override def receive() = 
+    {
+        case config: JsValue => 
+        {
+            // Get the Europeana url to query        
+            val query = (config \ "query").as[String]
+            val apikey = (config \ "apikey").as[String]
+            val maxresult = (config \ "maxresult").asOpt[Int]       
+         
+            // Create actor and kickstart
+            val europeanaActor = Akka.system.actorOf(Props(classOf[EuropeanaActor], self, query, apikey, maxresult))
+            europeanaActor ! new InitPacket()
+        }
+        case sp: StopPacket => cleanup
+        case ip: InitPacket => setup
+        case link: String => channel.push(new DataPacket(List(Map(resultName -> link))))
+        case x => Logger.error("Time generator got unexpected packet " + x + "\r\n")
+    }
+}
+

--- a/modules/dlib/app/tuktu/dlib/generators/europeanaGenerators.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/europeanaGenerators.scala
@@ -49,6 +49,12 @@ class EuropeanaActor(parentActor: ActorRef, query: String, apikey: String, maxre
         }
     }
     
+    /**
+     * Utility method to recursively call the Europeana API until either all the results or the requested number of results is reached
+     * @param query: a Europeana query without paging (&start) nor apikey (&wskey) parameters
+     * @param start: the first result to collect
+     * @return A stream of URLs pointing to the resulting Europeana metadata records 
+     */
     def callEuropeana( query: String, start: Int ): Stream[String] =
     {
         val encoding: String = "UTF8"

--- a/modules/dlib/app/tuktu/dlib/generators/oaipmh/listIdentifiersGenerator.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/oaipmh/listIdentifiersGenerator.scala
@@ -16,7 +16,7 @@ import tuktu.dlib.utils.oaipmh
 case class OAIIdentifiersPacket( ids: Seq[Node] )
 
 /**
- * Actor that harvests an OAI-PMH target
+ * Actor that harvests the record identifiers from an OAI-PMH target
  */
 class ListIdentifiersActor(parentActor: ActorRef, verb: String, params: String) extends Actor with ActorLogging 
 {
@@ -26,9 +26,7 @@ class ListIdentifiersActor(parentActor: ActorRef, verb: String, params: String) 
         case ip: InitPacket => self ! OAIRequestPacket( verb + params )
         
         case request: OAIRequestPacket => {
-          // println( "requested URL: " + request.request )
           val response = oaipmh.harvest( request.request )
-          // println( "response received: " + response.toString )
           (response \\ "error").headOption match{
               case None => self ! OAIResponsePacket( response )
               case Some( err ) => {
@@ -50,7 +48,6 @@ class ListIdentifiersActor(parentActor: ActorRef, verb: String, params: String) 
         {
             // send records to parent
             val headers = (rpacket.response \ "ListIdentifiers" \ "header" ).toSeq
-            // println( records.toString )
             // Send back to parent for pushing into channel
             parentActor ! OAIIdentifiersPacket( headers )
             // check for resumptionToken

--- a/modules/dlib/app/tuktu/dlib/generators/oaipmh/listMetadataFormatsGenerator.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/oaipmh/listMetadataFormatsGenerator.scala
@@ -15,6 +15,9 @@ import tuktu.dlib.utils.oaipmh
 
 case class OAIFormatsPacket( formats: Seq[Node] )
 
+/**
+ * Actor that obtains the metadata formats available from a repository
+ */
 class ListFormatsActor(parentActor: ActorRef, verb: String) extends Actor with ActorLogging 
 {
     

--- a/modules/dlib/app/tuktu/dlib/generators/oaipmh/listRecordsGenerator.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/oaipmh/listRecordsGenerator.scala
@@ -106,9 +106,7 @@ class ListRecordsGenerator( resultName: String, processors: List[Enumeratee[Data
           toj match{
             case false => channel.push( new DataPacket( List( Map( resultName -> error.error ) ) ) )
             case true => {
-              val xmlText = error.error.toString
-              val jsonText = org.json.XML.toJSONObject( xmlText ).toString( 4 )
-              val jsobj: JsObject = Json.parse( jsonText ).as[JsObject]
+              val jsobj: JsObject = oaipmh.xml2jsObject( error.error.toString )
               flatten match{
                 case true => channel.push( new DataPacket( List( tuktu.api.utils.JsObjectToMap( jsobj ) ) ) )
                 case false => channel.push( new DataPacket( List( Map( resultName -> jsobj ) ) ) )
@@ -123,9 +121,7 @@ class ListRecordsGenerator( resultName: String, processors: List[Enumeratee[Data
             toj match{
               case false => channel.push( new DataPacket( List( Map( resultName -> record ) ) ) )
               case true => {
-                val jsonText = org.json.XML.toJSONObject( record ).toString( 4 )
-                val jsobj: JsObject = Json.parse( jsonText ).as[JsObject]
-                val jo = (jsobj \ jsobj.keys.head).as[JsObject]
+                val jo = oaipmh.xml2jsObject( record )
                 flatten match{
                   case true => channel.push( new DataPacket( List( tuktu.api.utils.JsObjectToMap( jo ) ) ) )
                   case false => channel.push( new DataPacket( List( Map( resultName -> jo ) ) ) )

--- a/modules/dlib/app/tuktu/dlib/generators/oaipmh/listRecordsGenerator.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/oaipmh/listRecordsGenerator.scala
@@ -1,0 +1,158 @@
+package tuktu.dlib.generators.oaipmh
+
+import akka.actor._
+import akka.pattern.ask
+import java.util.concurrent.atomic.AtomicInteger
+import play.api.libs.concurrent.Akka
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import play.api.Logger
+import play.api.Play.current
+import scala.concurrent.ExecutionContext.Implicits.global
+import tuktu.api._
+import scala.io.Source
+import scala.io.Codec
+import scala.xml._
+
+case class OAIRequestPacket( request: String )
+case class OAIResponsePacket( response: Elem )
+case class OAIErrorPacket( error: Elem )
+case class OAIRecordsPacket( records: Seq[Node] )
+
+/**
+ * Actor that harvests an OAI-PMH target
+ */
+class HarvesterActor(parentActor: ActorRef, verb: String, params: String) extends Actor with ActorLogging 
+{
+    
+    def receive() = 
+    {   
+        case ip: InitPacket => self ! OAIRequestPacket( verb + params )
+        
+        case request: OAIRequestPacket => {
+          // println( "requested URL: " + request.request )
+          val response = harvest( request.request )
+          // println( "response received: " + response.toString )
+          (response \\ "error").headOption match{
+              case None => self ! OAIResponsePacket( response )
+              case Some( err ) => {
+                // Send back to parent for pushing into channel
+                parentActor ! OAIErrorPacket( response )
+                self ! new StopPacket
+              }
+          }
+        }
+        
+        case stop: StopPacket => 
+        {
+            // stop
+            parentActor ! new StopPacket
+            self ! PoisonPill
+        }
+        
+        case rpacket: OAIResponsePacket => 
+        {
+            // send records to parent
+            val records = (rpacket.response \ "ListRecords" \ "record" \ "metadata" ).flatMap( _.child ).toSeq
+            // println( records.toString )
+            // Send back to parent for pushing into channel
+            parentActor ! OAIRecordsPacket( records )
+            // check for resumptionToken
+            val rToken = (rpacket.response \ "ListRecords" \ "resumptionToken" ).headOption
+            rToken match
+            {
+              case Some( resumptionToken ) => self ! OAIRequestPacket( verb + "&resumptionToken=" + resumptionToken.text ) // keep harvesting
+              case None => self ! new StopPacket // harvesting completed
+            }
+             
+        }
+    }
+    
+    def harvest( request: String ): Elem =
+    {
+        val encoding: String = "UTF8"
+        val src: Source = Source.fromURL( request )( Codec.apply( encoding ) )
+        val txt = src.mkString
+        src.close()
+        XML.loadString( txt )
+    }
+}
+
+/**
+ * Harvests metadata records from an OAI-PMH target repository.
+ */
+class ListRecordsGenerator( resultName: String, processors: List[Enumeratee[DataPacket, DataPacket]], senderActor: Option[ActorRef] ) 
+    extends BaseGenerator(resultName, processors, senderActor) 
+{
+    var toj: Boolean = _
+    var flatten: Boolean = _
+    
+    override def receive() = 
+    {
+        case config: JsValue => 
+        {
+            // Get the ListRecords parameters        
+            val target = (config \ "target").as[String]
+            val metadataPrefix = (config \ "metadataPrefix").as[String]
+            val from = (config \ "from").asOpt[String]
+            val until = (config \ "until").asOpt[String]
+            val sets = (config \ "sets").asOpt[List[String]]
+            toj = (config \ "toJSON").asOpt[Boolean].getOrElse(false)
+            flatten = (config \ "flatten").asOpt[Boolean].getOrElse(false)
+         
+            val verb = target + "?verb=ListRecords" 
+            val params = "&metadataPrefix=" + metadataPrefix + (from match{
+              case None => ""
+              case Some(f) => "&from=" + f
+            }) + (until match{
+              case None => ""
+              case Some(u) => "&until=" + u
+            })
+            
+            sets match{
+              case None => val harvester = Akka.system.actorOf(Props(classOf[HarvesterActor], self, verb, params)); harvester ! new InitPacket()
+              case Some( s ) => for ( set <- s ) { val harvester = Akka.system.actorOf(Props(classOf[HarvesterActor], self, verb, params + "&set=" + set)); harvester ! new InitPacket() } 
+            }
+            
+        }
+        case sp: StopPacket => cleanup
+        case ip: InitPacket => setup
+        case error: OAIErrorPacket => {
+          toj match{
+            case false => channel.push( new DataPacket( List( Map( resultName -> error.error ) ) ) )
+            case true => {
+              val xmlText = error.error.toString
+              val jsonText = org.json.XML.toJSONObject( xmlText ).toString( 4 )
+              val jsobj: JsObject = Json.parse( jsonText ).as[JsObject]
+              flatten match{
+                case true => channel.push( new DataPacket( List( tuktu.api.utils.JsObjectToMap( jsobj ) ) ) )
+                case false => channel.push( new DataPacket( List( Map( resultName -> jsobj ) ) ) )
+              }
+            }
+          }
+        } 
+        case records: OAIRecordsPacket =>{
+            val recs = (records.records map { rec => rec.toString.trim })
+            for (record <- recs; if (!record.isEmpty))
+            {
+               // println( record.toString )
+               toj match{
+                   case false => channel.push( new DataPacket( List( Map( resultName -> record ) ) ) )
+                   case true => {
+                       val jsonText = org.json.XML.toJSONObject( record ).toString( 4 )
+                       val jsobj: JsObject = Json.parse( jsonText ).as[JsObject]
+                       val jo = (jsobj \ jsobj.keys.head).as[JsObject]
+                       flatten match{
+                           case true => channel.push( new DataPacket( List( tuktu.api.utils.JsObjectToMap( jo ) ) ) )
+                           case false => channel.push( new DataPacket( List( Map( resultName -> jo ) ) ) )
+                       }
+                  }
+            }
+            }
+        }
+        
+        case x => Logger.error("OAI-PMH ListRecords generator got unexpected packet " + x + "\r\n")
+    }
+
+}
+

--- a/modules/dlib/app/tuktu/dlib/generators/oaipmh/listRecordsGenerator.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/oaipmh/listRecordsGenerator.scala
@@ -50,7 +50,6 @@ class HarvesterActor(parentActor: ActorRef, verb: String, params: String) extend
         {
             // send records to parent
             val records = (rpacket.response \ "ListRecords" \ "record" \ "metadata" ).flatMap( _.child ).toSeq
-            // println( records.toString )
             // Send back to parent for pushing into channel
             parentActor ! OAIRecordsPacket( records )
             // check for resumptionToken

--- a/modules/dlib/app/tuktu/dlib/generators/oaipmh/listSetsGenerator.scala
+++ b/modules/dlib/app/tuktu/dlib/generators/oaipmh/listSetsGenerator.scala
@@ -15,6 +15,9 @@ import tuktu.dlib.utils.oaipmh
 
 case class OAISetsPacket( sets: Seq[Node] )
 
+/**
+ * Actor that obtains the set structure of a repository
+ */
 class ListSetsActor(parentActor: ActorRef, verb: String) extends Actor with ActorLogging 
 {
     

--- a/modules/dlib/app/tuktu/dlib/processors/europeanaQueryProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/europeanaQueryProcessor.scala
@@ -24,7 +24,7 @@ import tuktu.api._
 import tuktu.api.utils.evaluateTuktuString
 
 /**
- * @author dmssrt
+ * Queries the Europeana API and returns pointers to the resulting records.
  */
 class EuropeanaQueryProcessor(resultName: String) extends BaseProcessor(resultName) 
 {
@@ -49,7 +49,12 @@ class EuropeanaQueryProcessor(resultName: String) extends BaseProcessor(resultNa
             })
     })  
       
-    
+    /**
+     * Utility method to recursively call the Europeana API until either all the results or the requested number of results is reached
+     * @param query: a Europeana query without paging (&start) nor apikey (&wskey) parameters
+     * @param start: the first result to collect
+     * @return A stream of URLs pointing to the resulting Europeana metadata records 
+     */
     def callEuropeana( query: String, start: Int ): Stream[String] =
     {
         val encoding: String = "UTF8"

--- a/modules/dlib/app/tuktu/dlib/processors/europeanaQueryProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/europeanaQueryProcessor.scala
@@ -1,0 +1,77 @@
+package tuktu.dlib.processors
+
+import akka.util.Timeout
+
+import play.api.cache.Cache
+
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+
+import play.api.libs.ws.WS
+
+import play.api.Play.current
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.io.Source
+import scala.io.Codec
+
+import scala.Stream
+
+import tuktu.api._
+import tuktu.api.utils.evaluateTuktuString
+
+/**
+ * @author dmssrt
+ */
+class EuropeanaQueryProcessor(resultName: String) extends BaseProcessor(resultName) 
+{
+    var query: String = _
+    var apikey: String = _
+    var maxresult: Option[Int] = None
+    var total: Int = 0
+    
+    override def initialize(config: JsObject) 
+    {
+        // Get the Europeana url to query        
+        query = (config \ "query").as[String]
+        apikey = (config \ "apikey").as[String]
+        maxresult = (config \ "maxresult").asOpt[Int]
+    }
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future {
+      new DataPacket(for (datum <- data.data) yield {
+                val url =  evaluateTuktuString(query, datum)
+                total = 0
+                datum + ( resultName -> callEuropeana( url, 0 ) )
+            })
+    })  
+      
+    
+    def callEuropeana( query: String, start: Int ): Stream[String] =
+    {
+        val encoding: String = "UTF8"
+        val src: Source = Source.fromURL( query + "&start=" + (start + 1) + "&wskey=" + apikey )( Codec.apply( encoding ) )
+        val json = Json.parse( src.mkString )
+        src.close()
+        val itemsCount: Int = (json \ "itemsCount").as[Int]
+        val tr: Int = (json \ "totalResults").as[Int]
+        val totalResults: Int = maxresult match{
+          case None => tr
+          case Some(max) => if ((max < tr) && (max > 0)) max else tr
+        } 
+        val results: Stream[String] = (json \ "items").as[Stream[JsObject]].map{ x => (x \ "link").as[String] }
+        total = total + itemsCount
+        if (totalResults > total)
+        {
+            return results ++ callEuropeana( query, total )
+        }
+        else
+        {
+            return results
+        }       
+    }
+   
+}

--- a/modules/dlib/app/tuktu/dlib/processors/metadataSerializationProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/metadataSerializationProcessor.scala
@@ -1,0 +1,52 @@
+package tuktu.dlib.processors
+
+import java.io.File
+import org.apache.commons.io.FileUtils
+
+import play.api.cache.Cache
+
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+
+import play.api.Play.current
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import tuktu.api._
+
+/**
+ * Serializes a metadata record to a file.
+ */
+class MetadataSerializationProcessor(resultName: String) extends BaseProcessor(resultName) 
+{
+   var folder: String = _
+   var fileName: String = _
+   var prefix: String = _
+   var content: String = _
+   var postfix: String = _
+   var encoding: String = _
+    
+    override def initialize(config: JsObject) 
+    {
+        folder = (config \ "folder").as[String]
+        fileName = (config \ "fileName").as[String]
+        prefix = (config \ "prefix").asOpt[String].getOrElse("")
+        content = (config \ "content").as[String]
+        postfix = (config \ "postfix").asOpt[String].getOrElse("")
+        encoding = ( config \ "encoding" ).as[String]
+    }
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future {
+      new DataPacket(for (datum <- data.data) yield {
+                val path: String = utils.evaluateTuktuString(folder, datum) + File.separator + utils.evaluateTuktuString(fileName, datum)
+                val file: File = new File( path )
+                
+                val metadata: String = utils.evaluateTuktuString(prefix, datum) + "\n" + utils.evaluateTuktuString(content, datum) + "\n" + utils.evaluateTuktuString(postfix, datum) 
+                FileUtils.write( file, metadata, utils.evaluateTuktuString(encoding, datum) ) ;
+                datum
+            })
+    })   
+}

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/GetRecordProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/GetRecordProcessor.scala
@@ -42,7 +42,12 @@ class GetRecordProcessor(resultName: String) extends BaseProcessor(resultName)
         }        
       })
     })
-  
+    
+  /**
+   * Utility method to retrieve an individual metadata record from a repository
+   * @param verb: The OAI-PMH request containing the identifier of the record to get
+   * @return the corresponding metadata record
+   */
     def getRecord( verb: String ): String =
     {
       val response = oaipmh.harvest( verb )

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/GetRecordProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/GetRecordProcessor.scala
@@ -1,0 +1,60 @@
+package tuktu.dlib.processors.oaipmh
+
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml._
+import tuktu.api._
+import tuktu.api.BaseProcessor
+import tuktu.dlib.utils.oaipmh
+
+/**
+ * Retrieves an individual metadata record from a repository. Required arguments specify the identifier of the item from which the record is requested and the format of the metadata that should be included in the record.
+ */
+class GetRecordProcessor(resultName: String) extends BaseProcessor(resultName) 
+{
+   var target: String = _
+   var identifier: String = _
+   var metadataPrefix: String = _
+   var toj: Boolean = _
+    
+    override def initialize(config: JsObject) 
+    {
+        target = (config \ "target").as[String]
+        identifier = (config \ "identifier").as[String]
+        metadataPrefix = (config \ "metadataPrefix").as[String]
+        toj = (config \ "toJSON").asOpt[Boolean].getOrElse(false)
+    }
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future {
+      new DataPacket(for (datum <- data.data) yield {
+        val trgt = utils.evaluateTuktuString( target , datum )
+        val id = utils.evaluateTuktuString( identifier , datum )
+        val prefix = utils.evaluateTuktuString( metadataPrefix , datum )
+        val verb = trgt + "?verb=GetRecord&identifier=" + id + "&metadataPrefix=" + prefix
+        toj match
+        {
+          case false => datum + ( resultName -> getRecord( verb ) )
+          case true => datum + ( resultName ->  oaipmh.xml2jsObject( getRecord( verb ) ) )
+        }        
+      })
+    })
+  
+    def getRecord( verb: String ): String =
+    {
+      val response = oaipmh.harvest( verb )
+      // check for error
+      (response \\ "error").headOption match
+      {
+        case None => (response \ "GetRecord" \ "record" \ "@status" ).headOption match
+        {
+          case Some( status ) => status.text
+          case None => (for ( record <- (response \ "GetRecord" \ "record" \ "metadata").head.child; if ( !record.toString.trim.isEmpty ) ) yield{ record.toString }).head
+        }
+        case Some( err ) => response.toString
+      }
+    }
+}

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListMetadataFormatsProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListMetadataFormatsProcessor.scala
@@ -1,0 +1,61 @@
+package tuktu.dlib.processors.oaipmh
+
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml._
+import tuktu.api._
+import tuktu.api.BaseProcessor
+import tuktu.dlib.utils.oaipmh
+
+/**
+ * Retrieves the metadata formats available from a repository. An optional argument restricts the request to the formats available for a specific item.
+ */
+class ListMetadataFormatsProcessor(resultName: String) extends BaseProcessor(resultName) 
+{
+   var target: String = _
+   var identifier: Option[String] = _
+   var toj: Boolean = _
+    
+    override def initialize(config: JsObject) 
+    {
+        target = (config \ "target").as[String]
+        identifier = (config \ "identifier").asOpt[String]
+        toj = (config \ "toJSON").asOpt[Boolean].getOrElse(false)
+    }
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future {
+      new DataPacket(for (datum <- data.data) yield {
+        val trgt = utils.evaluateTuktuString( target , datum )
+        val id = identifier match
+        {
+          case None => ""
+          case Some( i ) => "&identifier=" + utils.evaluateTuktuString( i , datum )
+        }
+        val verb = trgt + "?verb=ListMetadataFormats" + id
+        println( verb )
+        toj match
+        {
+          case false => datum + ( resultName -> getFormats( verb ) )
+          case true => datum + ( resultName ->  getFormats( verb ).map{ f => oaipmh.xml2jsObject( f ) }  )
+        }        
+      })
+    })
+  
+    def getFormats( verb: String ): Seq[String] =
+    {
+      val response = oaipmh.harvest( verb )
+      // check for error
+      (response \\ "error").headOption match
+      {
+        case None => {
+          val f = ((response \ "ListMetadataFormats" \ "metadataFormat" ).toSeq map { frmt => frmt.toString.trim })
+          for (format <- f; if (!format.isEmpty)) yield( format )
+        }  
+        case Some( err ) => Seq(response.toString)
+      }
+    }
+}

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListMetadataFormatsProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListMetadataFormatsProcessor.scala
@@ -36,7 +36,6 @@ class ListMetadataFormatsProcessor(resultName: String) extends BaseProcessor(res
           case Some( i ) => "&identifier=" + utils.evaluateTuktuString( i , datum )
         }
         val verb = trgt + "?verb=ListMetadataFormats" + id
-        println( verb )
         toj match
         {
           case false => datum + ( resultName -> getFormats( verb ) )
@@ -44,7 +43,11 @@ class ListMetadataFormatsProcessor(resultName: String) extends BaseProcessor(res
         }        
       })
     })
-  
+  /**
+   * Utility method to retrieve the metadata formats supported by a repository
+   * @param verb: The OAI-PMH ListFormats request
+   * @return the metadata formats supported by the repository
+   */
     def getFormats( verb: String ): Seq[String] =
     {
       val response = oaipmh.harvest( verb )

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListSetsProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListSetsProcessor.scala
@@ -1,0 +1,58 @@
+package tuktu.dlib.processors.oaipmh
+
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml._
+import tuktu.api._
+import tuktu.api.BaseProcessor
+import tuktu.dlib.utils.oaipmh
+
+/**
+ * Retrieves the set structure of a repository.
+ */
+class ListSetsProcessor(resultName: String) extends BaseProcessor(resultName) 
+{
+   var target: String = _
+   var toj: Boolean = _
+    
+    override def initialize(config: JsObject) 
+    {
+        target = (config \ "target").as[String]
+        toj = (config \ "toJSON").asOpt[Boolean].getOrElse(false)
+    }
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future {
+      new DataPacket(for (datum <- data.data) yield {
+        val trgt = utils.evaluateTuktuString( target , datum )
+        toj match
+        {
+          case false => datum + ( resultName -> getSets( trgt, "?verb=ListSets" ) )
+          case true => datum + ( resultName ->  getSets( trgt, "?verb=ListSets" ).map{ f => oaipmh.xml2jsObject( f ) }  )
+        }        
+      })
+    })
+  
+    def getSets( target: String, verb: String ): Seq[String] =
+    {
+      val response = oaipmh.harvest( target + verb )
+      // check for error
+      (response \\ "error").headOption match
+      {
+        case None => {
+          val sts = ( response \ "ListSets" \ "set" ).toSeq map { set => set.toString.trim }
+          val sets = for ( set <- sts; if ( !set.isEmpty ) ) yield( set )
+          val rToken = ( response \ "ListSets" \ "resumptionToken" ).headOption
+          rToken match
+            {
+              case Some( resumptionToken ) => sets ++ getSets( target, ("?verb=ListSets&resumptionToken=" + resumptionToken.text) ) // keep harvesting
+              case None => sets // harvesting completed
+            }
+        }  
+        case Some( err ) => Seq(response.toString)
+      }
+    }
+}

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListSetsProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/ListSetsProcessor.scala
@@ -36,6 +36,12 @@ class ListSetsProcessor(resultName: String) extends BaseProcessor(resultName)
       })
     })
   
+  /**
+   * Recursive utility method to retrieve the set structure of a repository
+   * @param target: The URL of the repository
+   * @param verb: the ListSets verb and its parameters
+   * @return the complete set structure of the repository
+   */
     def getSets( target: String, verb: String ): Seq[String] =
     {
       val response = oaipmh.harvest( target + verb )

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/harvesterProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/harvesterProcessor.scala
@@ -77,6 +77,14 @@ class HarvesterProcessor(genActor: ActorRef, resultName: String) extends BufferP
         }
     }) compose Enumeratee.onEOF(() => packetSenderActor ! new StopPacket)
     
+  /**
+   * Utility method to (selectively) harvest metadata records (or their identifiers) from a repository
+   * @param verb: The OAI-PMH verb url (listrecords or listidentifiers)
+   * @param params: The harvesting parameters for the verb considered
+   * @param datum: The datum containing the query 
+   * @return the corresponding metadata records or identifiers packaged in separate data packets.
+   */
+
     def listRecords( verb: String, params: String, datum: Map[String, Any] ): Seq[Future[Any]] =
     {
         val response = oaipmh.harvest( verb + params )

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/identifyProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/identifyProcessor.scala
@@ -1,0 +1,50 @@
+package tuktu.dlib.processors.oaipmh
+
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml._
+import tuktu.api._
+import tuktu.api.BaseProcessor
+import tuktu.dlib.utils.oaipmh
+
+/**
+ * Retrieves information about a repository.
+ */
+class IdentifyProcessor (resultName: String) extends BaseProcessor(resultName) 
+{
+   var target: String = _
+   var toj: Boolean = _
+    
+    override def initialize(config: JsObject) 
+    {
+        target = (config \ "target").as[String]
+        toj = (config \ "toJSON").asOpt[Boolean].getOrElse(false)
+    }
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future {
+      new DataPacket(for (datum <- data.data) yield {
+        val trgt = utils.evaluateTuktuString( target , datum)
+        toj match
+        {
+          case false => datum + ( resultName -> getIdentity( trgt ) )
+          case true => datum + ( resultName ->  oaipmh.xml2jsObject( getIdentity( trgt ) ) )
+        }        
+      })
+    })
+  
+    def getIdentity( target: String ): String =
+    {
+      val verb = target + "?verb=Identify"
+      val response = oaipmh.harvest( verb )
+      // check for error
+      (response \\ "error").headOption match
+      {
+        case None => (response \ "Identify").head.toString
+        case Some( err ) => response.toString
+      }
+    }
+}

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/identifyProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/identifyProcessor.scala
@@ -35,7 +35,11 @@ class IdentifyProcessor (resultName: String) extends BaseProcessor(resultName)
         }        
       })
     })
-  
+  /**
+   * Utility method to retrieve a repository description
+   * @param target: The OAI-PMH identify request
+   * @return the repository description
+   */
     def getIdentity( target: String ): String =
     {
       val verb = target + "?verb=Identify"

--- a/modules/dlib/app/tuktu/dlib/processors/oaipmh/listRecordsProcessor.scala
+++ b/modules/dlib/app/tuktu/dlib/processors/oaipmh/listRecordsProcessor.scala
@@ -1,0 +1,128 @@
+package tuktu.dlib.processors.oaipmh
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import akka.actor._
+import akka.pattern.ask
+import akka.util.Timeout
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json.JsValue
+import play.api.libs.concurrent.Akka
+import play.api.Play.current
+import tuktu.api._
+import play.api.libs.json._
+import play.api.cache.Cache
+import scala.collection.mutable.ListBuffer
+import tuktu.dlib.utils._
+
+/**
+ * Harvests metadata records from an OAI-PMH target repository.
+ */
+class ListRecordsProcessor(genActor: ActorRef, resultName: String) extends BufferProcessor(genActor, resultName) {
+    implicit val timeout = Timeout(Cache.getAs[Int]("timeout").getOrElse(5) seconds)
+    
+    // Set up the packet sender actor
+    val packetSenderActor = Akka.system.actorOf(Props(classOf[PacketSenderActor], genActor))
+    
+    var target: String = _
+    var metadataPrefix: String = _
+    var from: Option[String] = _
+    var until: Option[String] = _
+    var set: Option[String] = _
+    var toj: Boolean = _
+    
+    override def initialize(config: JsObject) 
+    {
+        target = (config \ "target").as[String]
+        metadataPrefix = (config \ "metadataPrefix").as[String]
+        from = (config \ "from").asOpt[String]
+        until = (config \ "until").asOpt[String]
+        set = (config \ "set").asOpt[String]
+        toj = (config \ "toJSON").asOpt[Boolean].getOrElse(false)
+    }
+    
+    
+    
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => {
+        val futures = Future.sequence( 
+            (for (datum <- data.data) yield
+            {
+               // compose verb
+               val verb = utils.evaluateTuktuString(target, datum) + "?verb=ListRecords"
+               // compose params
+               val params = "&metadataPrefix=" + utils.evaluateTuktuString(metadataPrefix, datum) + (from match{
+                  case None => ""
+                  case Some(f) => "&from=" + utils.evaluateTuktuString(f, datum)
+                }) + (until match{
+                  case None => ""
+                  case Some(u) => "&until=" + utils.evaluateTuktuString(u, datum)
+                }) + (set match{
+                  case None => ""
+                  case Some(s) => "&set=" + utils.evaluateTuktuString(s, datum)
+                })
+              // harvest
+              listRecords( verb, params, datum )
+            }).flatMap { x => x }
+        )
+        
+        futures.map {
+            case _ => data
+        }
+    }) compose Enumeratee.onEOF(() => packetSenderActor ! new StopPacket)
+    
+    def listRecords( verb: String, params: String, datum: Map[String, Any] ): Seq[Future[Any]] =
+    {
+        val response = oaipmh.harvest( verb + params )
+        // check for error
+      (response \\ "error").headOption match
+      {
+        case None => {
+          // extract records and send them to channel
+          val records = (response \ "ListRecords" \ "record" \ "metadata" ).flatMap( _.child ).toSeq
+          val recs = (records map { rec => rec.toString.trim })
+          val result = for (record <- recs; if (!record.isEmpty)) yield
+          {
+            toj match{
+              case false => packetSenderActor ? (datum + ( resultName -> record ))
+              case true => packetSenderActor ? (datum + ( resultName -> oaipmh.xml2jsObject( record ) ))
+            }
+          }
+          // check for resumption token
+          val rToken = ( response \ "ListRecords" \ "resumptionToken" ).headOption
+          rToken match
+            {
+              case Some( resumptionToken ) => result ++ listRecords( verb, ("&resumptionToken=" + resumptionToken.text), datum ) // keep harvesting
+              case None => result // harvesting completed
+            }
+        }  
+        case Some( err ) => {
+          toj match{
+              case false => Seq(packetSenderActor ? (datum + ( resultName -> response.toString )))
+              case true => Seq(packetSenderActor ? (datum + ( resultName -> oaipmh.xml2jsObject( response.toString ) )))
+            }
+        }
+          
+      }
+    }
+}
+
+/**
+ * Actor for forwarding the split data packets
+ */
+class PacketSenderActor(remoteGenerator: ActorRef) extends Actor with ActorLogging {
+    remoteGenerator ! new InitPacket
+    
+    def receive() = {
+        case sp: StopPacket => {
+            remoteGenerator ! sp
+            self ! PoisonPill
+        }
+        case datum: Map[String, Any] => {
+            // Directly forward
+            remoteGenerator ! new DataPacket(List(datum))
+            sender ! "ok"
+        }
+    }
+}

--- a/modules/dlib/app/tuktu/dlib/utils/oaipmh.scala
+++ b/modules/dlib/app/tuktu/dlib/utils/oaipmh.scala
@@ -1,0 +1,17 @@
+package tuktu.dlib.utils
+
+import scala.io.Source
+import scala.io.Codec
+import scala.xml._
+
+object oaipmh 
+{
+    def harvest( request: String ): Elem =
+    {
+        val encoding: String = "UTF8"
+        val src: Source = Source.fromURL( request )( Codec.apply( encoding ) )
+        val txt = src.mkString
+        src.close()
+        XML.loadString( txt )
+    }  
+}

--- a/modules/dlib/app/tuktu/dlib/utils/oaipmh.scala
+++ b/modules/dlib/app/tuktu/dlib/utils/oaipmh.scala
@@ -2,13 +2,25 @@ package tuktu.dlib.utils
 
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
+import play.api.libs.ws.WS
+import play.api.Play.current
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.io.Source
 import scala.io.Codec
 import scala.xml._
 
 
+/**
+ * Some utility functions to automate repetitive OAI-PMH tasks
+ */
 object oaipmh 
 {
+    /**
+     * Sends a request to an OAI-PMH target
+     * @param request: A valid OAI-PMH request 
+     * @return An OAI-PMH response
+     */
     def harvest( request: String ): Elem =
     {
         val encoding: String = "UTF8"
@@ -18,10 +30,26 @@ object oaipmh
         XML.loadString( txt )
     }
     
+    /**
+     * Turns XML (as a string) into a JSON object (as a JsObject)  
+     * @param xml: The XML document to convert 
+     * @return A JSON object equivalent of the XML provided 
+     */
     def xml2jsObject( xml: String ): JsObject =
     {
         val jsonText = org.json.XML.toJSONObject( xml ).toString( 4 )
         val jsobj: JsObject = Json.parse( jsonText ).as[JsObject]
         (jsobj \ jsobj.keys.head).as[JsObject]  
     }
+    
+    /**
+     * A non-blocking version of the harvest method Sends a request to an OAI-PMH target
+     * @param request: A valid OAI-PMH request 
+     * @return A future OAI-PMH response
+     */
+    def fharvest(url: String): Future[scala.xml.Elem] = 
+    {
+        WS.url(url).get().map { response => response.xml }
+    }
+    
 }

--- a/modules/dlib/app/tuktu/dlib/utils/oaipmh.scala
+++ b/modules/dlib/app/tuktu/dlib/utils/oaipmh.scala
@@ -1,8 +1,11 @@
 package tuktu.dlib.utils
 
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
 import scala.io.Source
 import scala.io.Codec
 import scala.xml._
+
 
 object oaipmh 
 {
@@ -13,5 +16,12 @@ object oaipmh
         val txt = src.mkString
         src.close()
         XML.loadString( txt )
-    }  
+    }
+    
+    def xml2jsObject( xml: String ): JsObject =
+    {
+        val jsonText = org.json.XML.toJSONObject( xml ).toString( 4 )
+        val jsobj: JsObject = Json.parse( jsonText ).as[JsObject]
+        (jsobj \ jsobj.keys.head).as[JsObject]  
+    }
 }

--- a/modules/dlib/conf/application.conf
+++ b/modules/dlib/conf/application.conf
@@ -1,0 +1,44 @@
+# This is the main configuration file for the application.
+# ~~~~~
+
+# Secret key
+# ~~~~~
+# The secret key is used to secure cryptographics functions.
+#
+# This must be changed for production, but we recommend not changing it in this file.
+#
+# See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
+play.crypto.secret = "changeme"
+
+# The application languages
+# ~~~~~
+play.i18n.langs = [ "en" ]
+
+# Router
+# ~~~~~
+# Define the Router object to use for this application.
+# This router will be looked up first when the application is starting up,
+# so make sure this is the entry point.
+# Furthermore, it's assumed your route file is named properly.
+# So for an application router like `my.application.Router`,
+# you may need to define a router file `conf/my.application.routes`.
+# Default to Routes in the root package (and conf/routes)
+# play.http.router = my.application.Routes
+
+# Database configuration
+# ~~~~~
+# You can declare as many datasources as you want.
+# By convention, the default datasource is named `default`
+#
+# db.default.driver=org.h2.Driver
+# db.default.url="jdbc:h2:mem:play"
+# db.default.username=sa
+# db.default.password=""
+
+# Evolutions
+# ~~~~~
+# You can disable evolutions if needed
+# play.evolutions.enabled=false
+
+# You can disable evolutions for a specific datasource if necessary
+# play.evolutions.db.default.enabled=false

--- a/modules/dlib/conf/logback.xml
+++ b/modules/dlib/conf/logback.xml
@@ -1,0 +1,22 @@
+<configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel - %logger - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <!--
+    The logger name is typically the Java/Scala package name.
+    This configures the log level to log at for a package and its children packages.
+  -->
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListIdentifiersGenerator.json
+++ b/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListIdentifiersGenerator.json
@@ -1,0 +1,105 @@
+{
+	"name": "ListIdentifiers Generator",
+	"description": "Harvests metadata record identifiers from an OAI-PMH target repository.",
+	"class": "tuktu.dlib.generators.oaipmh.ListIdentifiersGenerator",
+	"parameters": [
+		{
+			"name": "nodes",
+			"type": "array",
+			"required": false,
+			"description": "Optionally specify on which nodes to run and how many instances you want on each node.",
+			"parameters": [
+				{
+					"name": "",
+					"type": "object",
+					"required": true,
+					"parameters": [
+						{
+							"name": "type",
+							"type": "string",
+							"required": true,
+							"description": "The type of node handler, one of SingleNode, SomeNodes, AllNodes (leave empty for local execution)"
+						},
+						{
+							"name": "nodes",
+							"type": "string",
+							"required": true,
+							"description": "The nodes to use for this node handler type"
+						},
+						{
+							"name": "instances",
+							"type": "int",
+							"required": false,
+							"default": 1,
+							"description": "The amount of instances per node of this handler type"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "target",
+					"description": "The URL of the OAI-PMH target to harvest.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "metadataPrefix",
+					"description": "A required argument that specifies the metadataPrefix of the format that should be included in the metadata part of the returned records (e.g., Dublin Core: oai_dc, IEEE LOM: oai_lom).",
+					"type": "string",
+					"required": true,
+					"default": "oai_dc"
+				},
+				{
+					"name": "from",
+					"description": "An optional argument with a UTCdatetime value, which specifies a lower bound for datestamp-based selective harvesting.",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "until",
+					"description": "An optional argument with a UTCdatetime value, which specifies a upper bound for datestamp-based selective harvesting.",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "sets",
+					"description": "An optional argument that specifies the set(s) to selectively harvest.",
+					"type": "array",
+					"required": false,
+					"parameters": [
+						{
+							"name": "",
+							"type": "string",
+							"required": true
+						}
+					]
+				},
+				{
+					"name": "toJSON",
+					"description": "Convert harvested XML headers to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				},
+				{
+					"name": "flatten",
+					"description": "Flatten JSON headers?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListMetadataFormatsGenerator.json
+++ b/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListMetadataFormatsGenerator.json
@@ -1,0 +1,79 @@
+{
+	"name": "ListMetadataFormats Generator",
+	"description": "Retrieves the metadata formats available from a repository. An optional argument restricts the request to the formats available for a specific item.",
+	"class": "tuktu.dlib.generators.oaipmh.ListMetadataFormatsGenerator",
+	"parameters": [
+		{
+			"name": "nodes",
+			"type": "array",
+			"required": false,
+			"description": "Optionally specify on which nodes to run and how many instances you want on each node.",
+			"parameters": [
+				{
+					"name": "",
+					"type": "object",
+					"required": true,
+					"parameters": [
+						{
+							"name": "type",
+							"type": "string",
+							"required": true,
+							"description": "The type of node handler, one of SingleNode, SomeNodes, AllNodes (leave empty for local execution)"
+						},
+						{
+							"name": "nodes",
+							"type": "string",
+							"required": true,
+							"description": "The nodes to use for this node handler type"
+						},
+						{
+							"name": "instances",
+							"type": "int",
+							"required": false,
+							"default": 1,
+							"description": "The amount of instances per node of this handler type"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "target",
+					"description": "The URL of the OAI-PMH target repository.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "identifier",
+					"description": "An optional argument that specifies the unique identifier of the item for which available metadata formats are being requested. If this argument is omitted, then the response includes all metadata formats supported by the target repository.",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "toJSON",
+					"description": "Converts XML set descriptions to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				},
+				{
+					"name": "flatten",
+					"description": "Flattens JSON set descriptions?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListRecordsGenerator.json
+++ b/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListRecordsGenerator.json
@@ -1,0 +1,105 @@
+{
+	"name": "ListRecords Generator",
+	"description": "Harvests metadata records from an OAI-PMH target repository.",
+	"class": "tuktu.dlib.generators.oaipmh.ListRecordsGenerator",
+	"parameters": [
+		{
+			"name": "nodes",
+			"type": "array",
+			"required": false,
+			"description": "Optionally specify on which nodes to run and how many instances you want on each node.",
+			"parameters": [
+				{
+					"name": "",
+					"type": "object",
+					"required": true,
+					"parameters": [
+						{
+							"name": "type",
+							"type": "string",
+							"required": true,
+							"description": "The type of node handler, one of SingleNode, SomeNodes, AllNodes (leave empty for local execution)"
+						},
+						{
+							"name": "nodes",
+							"type": "string",
+							"required": true,
+							"description": "The nodes to use for this node handler type"
+						},
+						{
+							"name": "instances",
+							"type": "int",
+							"required": false,
+							"default": 1,
+							"description": "The amount of instances per node of this handler type"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "target",
+					"description": "The URL of the OAI-PMH target to harvest.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "metadataPrefix",
+					"description": "A required argument that specifies the metadataPrefix of the format that should be included in the metadata part of the returned records (e.g., Dublin Core: oai_dc, IEEE LOM: oai_lom).",
+					"type": "string",
+					"required": true,
+					"default": "oai_dc"
+				},
+				{
+					"name": "from",
+					"description": "An optional argument with a UTCdatetime value, which specifies a lower bound for datestamp-based selective harvesting.",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "until",
+					"description": "An optional argument with a UTCdatetime value, which specifies a upper bound for datestamp-based selective harvesting.",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "sets",
+					"description": "An optional argument that specifies the set(s) to selectively harvest.",
+					"type": "array",
+					"required": false,
+					"parameters": [
+						{
+							"name": "",
+							"type": "string",
+							"required": true
+						}
+					]
+				},
+				{
+					"name": "toJSON",
+					"description": "Convert harvested XML records to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				},
+				{
+					"name": "flatten",
+					"description": "Flatten JSON records?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListSetsGenerator.json
+++ b/modules/modeller/meta/generators/dlib/oaipmh/tuktu.dlib.generators.oaipmh.ListSetsGenerator.json
@@ -1,0 +1,73 @@
+{
+	"name": "ListSets Generator",
+	"description": "Retrieves the set structure of a repository.",
+	"class": "tuktu.dlib.generators.oaipmh.ListSetsGenerator",
+	"parameters": [
+		{
+			"name": "nodes",
+			"type": "array",
+			"required": false,
+			"description": "Optionally specify on which nodes to run and how many instances you want on each node.",
+			"parameters": [
+				{
+					"name": "",
+					"type": "object",
+					"required": true,
+					"parameters": [
+						{
+							"name": "type",
+							"type": "string",
+							"required": true,
+							"description": "The type of node handler, one of SingleNode, SomeNodes, AllNodes (leave empty for local execution)"
+						},
+						{
+							"name": "nodes",
+							"type": "string",
+							"required": true,
+							"description": "The nodes to use for this node handler type"
+						},
+						{
+							"name": "instances",
+							"type": "int",
+							"required": false,
+							"default": 1,
+							"description": "The amount of instances per node of this handler type"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "target",
+					"description": "The URL of the OAI-PMH target repository.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "toJSON",
+					"description": "Converts XML set descriptions to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				},
+				{
+					"name": "flatten",
+					"description": "Flattens JSON set descriptions?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/generators/dlib/tuktu.dlib.generators.EuropeanaGenerator.json
+++ b/modules/modeller/meta/generators/dlib/tuktu.dlib.generators.EuropeanaGenerator.json
@@ -1,0 +1,71 @@
+{
+	"name": "Europeana Generator",
+	"description": "Queries the Europeana API and returns pointers to the resulting records.",
+	"class": "tuktu.dlib.generators.EuropeanaGenerator",
+	"parameters": [
+		{
+			"name": "nodes",
+			"type": "array",
+			"required": false,
+			"description": "Optionally specify on which nodes to run and how many instances you want on each node.",
+			"parameters": [
+				{
+					"name": "",
+					"type": "object",
+					"required": true,
+					"parameters": [
+						{
+							"name": "type",
+							"type": "string",
+							"required": true,
+							"description": "The type of node handler, one of SingleNode, SomeNodes, AllNodes (leave empty for local execution)"
+						},
+						{
+							"name": "nodes",
+							"type": "string",
+							"required": true,
+							"description": "The nodes to use for this node handler type"
+						},
+						{
+							"name": "instances",
+							"type": "int",
+							"required": false,
+							"default": 1,
+							"description": "The amount of instances per node of this handler type"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "query",
+					"description": "A Europeana API query.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "apikey",
+					"description": "A Europeana API key.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "maxresult",
+					"description": "The maximum number of results to be returned by each query.",
+					"type": "int",
+					"required": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.GetRecordProcessor.json
+++ b/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.GetRecordProcessor.json
@@ -1,0 +1,49 @@
+{
+	"name": "GetRecord Processor",
+	"description": "Retrieves an individual metadata record from a repository. Required arguments specify the identifier of the item from which the record is requested and the format of the metadata that should be included in the record.",
+	"class": "tuktu.dlib.processors.oaipmh.GetRecordProcessor",
+	"parameters": [
+		{
+			"name": "id",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "target",
+					"description": "The OAI-PMH target repository.",
+					"type": "string",
+					"required": true
+				},
+			    {
+					"name": "identifier",
+					"description": "A required argument that specifies the unique identifier of the item in the repository from which the record must be disseminated.",
+					"type": "string",
+					"required": true
+				},
+			    {
+					"name": "metadataPrefix",
+					"description": "A required argument that specifies the metadataPrefix of the format that should be included in the metadata part of the returned record.",
+					"type": "string",
+					"required": true
+				},
+			    {
+					"name": "toJSON",
+					"description": "Converts XML description to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.HarvesterProcessor.json
+++ b/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.HarvesterProcessor.json
@@ -1,7 +1,7 @@
 {
-    "name": "ListRecords Processor",
-    "description": "Harvests metadata records from an OAI-PMH target repository.",
-    "class": "tuktu.dlib.processors.oaipmh.ListRecordsProcessor",
+    "name": "Harvester Processor",
+    "description": "Harvests metadata records (ListRecords) or metadata records identifiers (ListIdentifiers) from an OAI-PMH target repository.",
+    "class": "tuktu.dlib.processors.oaipmh.HarvesterProcessor",
     "parameters": [
         {
             "name": "id",
@@ -18,6 +18,13 @@
             "type": "object",
             "required": true,
             "parameters": [
+                {
+                    "name": "identifiersOnly",
+                    "description": "Only harvest the record identifiers (ListIdentifiers) instead of the full metadata records (ListRecords)?",
+                    "type": "boolean",
+                    "required": true,
+                    "default": false
+                },
                 {
                     "name": "target",
                     "description": "The URL of the OAI-PMH target to harvest.",

--- a/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.IdentifyProcessor.json
+++ b/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.IdentifyProcessor.json
@@ -1,0 +1,37 @@
+{
+	"name": "Identify Processor",
+	"description": "Retrieves information about a repository.",
+	"class": "tuktu.dlib.processors.oaipmh.IdentifyProcessor",
+	"parameters": [
+		{
+			"name": "id",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "target",
+					"description": "The OAI-PMH repository target to identify.",
+					"type": "string",
+					"required": true
+				},
+			    {
+					"name": "toJSON",
+					"description": "Converts XML description to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.ListMetadataFormatsProcessor.json
+++ b/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.ListMetadataFormatsProcessor.json
@@ -1,0 +1,43 @@
+{
+    "name": "ListMetadataFormats Processor",
+    "description": "Retrieves the metadata formats available from a repository. An optional argument restricts the request to the formats available for a specific item.",
+    "class": "tuktu.dlib.processors.oaipmh.ListMetadataFormatsProcessor",
+    "parameters": [
+        {
+            "name": "id",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "result",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "config",
+            "type": "object",
+            "required": true,
+            "parameters": [
+                {
+                    "name": "target",
+                    "description": "The URL of the OAI-PMH target repository.",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "identifier",
+                    "description": "An optional argument that specifies the unique identifier of the item for which available metadata formats are being requested. If this argument is omitted, then the response includes all metadata formats supported by the target repository.",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "toJSON",
+                    "description": "Converts XML set descriptions to JSON?",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false
+                }
+            ]
+        }
+    ]
+}

--- a/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.ListRecordsProcessor.json
+++ b/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.ListRecordsProcessor.json
@@ -1,0 +1,62 @@
+{
+    "name": "ListRecords Processor",
+    "description": "Harvests metadata records from an OAI-PMH target repository.",
+    "class": "tuktu.dlib.processors.oaipmh.ListRecordsProcessor",
+    "parameters": [
+        {
+            "name": "id",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "result",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "config",
+            "type": "object",
+            "required": true,
+            "parameters": [
+                {
+                    "name": "target",
+                    "description": "The URL of the OAI-PMH target to harvest.",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "metadataPrefix",
+                    "description": "A required argument that specifies the metadataPrefix of the format that should be included in the metadata part of the returned records (e.g., Dublin Core: oai_dc, IEEE LOM: oai_lom).",
+                    "type": "string",
+                    "required": true,
+                    "default": "oai_dc"
+                },
+                {
+                    "name": "from",
+                    "description": "An optional argument with a UTCdatetime value, which specifies a lower bound for datestamp-based selective harvesting.",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "until",
+                    "description": "An optional argument with a UTCdatetime value, which specifies a upper bound for datestamp-based selective harvesting.",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "set",
+                    "description": "An optional argument that specifies the set to selectively harvest.",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "toJSON",
+                    "description": "Convert harvested XML records to JSON?",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false
+                }
+            ]
+        }
+    ]
+}

--- a/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.ListSetsProcessor.json
+++ b/modules/modeller/meta/processors/dlib/oaimph/tuktu.dlib.processors.oaipmh.ListSetsProcessor.json
@@ -1,0 +1,37 @@
+{
+	"name": "ListSets Processor",
+	"description": "Retrieves the set structure of a repository.",
+	"class": "tuktu.dlib.processors.oaipmh.ListSetsProcessor",
+    "parameters": [
+        {
+            "name": "id",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "result",
+            "type": "string",
+            "required": true
+        },
+        {
+            "name": "config",
+            "type": "object",
+            "required": true,
+            "parameters": [
+                {
+					"name": "target",
+					"description": "The URL of the OAI-PMH target repository.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "toJSON",
+					"description": "Converts XML set descriptions to JSON?",
+					"type": "boolean",
+					"required": false,
+					"default": false
+				}
+            ]
+        }
+    ]
+}

--- a/modules/modeller/meta/processors/dlib/tuktu.dlib.processors.EuropeanaQueryProcessor.json
+++ b/modules/modeller/meta/processors/dlib/tuktu.dlib.processors.EuropeanaQueryProcessor.json
@@ -1,0 +1,42 @@
+{
+	"name": "Europeana Query Processor",
+	"description": "Queries the Europeana API and returns pointers to the resulting records.",
+	"class": "tuktu.dlib.processors.EuropeanaQueryProcessor",
+	"parameters": [
+		{
+			"name": "id",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "query",
+					"description": "A Europeana API query.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "apikey",
+					"description": "A Europeana API key.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "maxresult",
+					"description": "The maximum number of results to be returned by each query.",
+					"type": "int",
+					"required": false
+				}
+			]
+		}
+	]
+}

--- a/modules/modeller/meta/processors/dlib/tuktu.dlib.processors.MetadataSerializationProcessor.json
+++ b/modules/modeller/meta/processors/dlib/tuktu.dlib.processors.MetadataSerializationProcessor.json
@@ -1,0 +1,61 @@
+{
+	"name": "Metadata Serialization Processor",
+	"description": "Serializes a metadata record to a file.",
+	"class": "tuktu.dlib.processors.MetadataSerializationProcessor",
+	"parameters": [
+		{
+			"name": "id",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": [
+				{
+					"name": "folder",
+					"description": "The folder in which the metadata record will be saved.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "fileName",
+					"description": "The name of the metadata record file to create",
+					"type": "string",
+					"required": true
+				},
+			    {
+					"name": "prefix",
+					"description": "A header to prefix to the metadata record (e.g., <?xml version=\"1.0\" encoding=\"UTF-8\"?>).",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "content",
+					"description": "The main metadata content of the record.",
+					"type": "string",
+					"required": true
+				},
+				{
+					"name": "postfix",
+					"description": "A footer to postfix to the metadata record.",
+					"type": "string",
+					"required": false
+				},
+				{
+					"name": "encoding",
+					"description": "The file encoding",
+					"type": "string",
+					"required": true,
+					"default": "utf-8"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Hi Erik and All,

I would like to add a “dl” (for digital library) module to tuktu.  It will contain generators and processors to deal with different digital library APIs, protocols, and metadata formats?  This initial version comes with support for the OAI-PMH protocol and the Europeana.eu.  I plan to further develop it in the coming weeks and months.

What do you think?

Best,

David
