### PR TITLE
upgrade to reactivemongo 0.11.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ lazy val nosqlDependencies = Seq(
     "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
     "org.xerial" % "sqlite-jdbc" % "3.8.7",
     "org.apache.kafka" %% "kafka" % "0.8.2-beta",
-    "org.reactivemongo" %% "play2-reactivemongo" % "0.11.7.play23",
+    "org.reactivemongo" %% "play2-reactivemongo" % "0.11.11-play23",
     "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.4",
     "org.elasticsearch" % "elasticsearch" % "1.4.4",
     "org.apache.hadoop" % "hadoop-client" % "2.6.0",
@@ -356,3 +356,5 @@ lazy val root = project
     .settings(EclipseKeys.skipParents in ThisBuild := false)
     .aggregate(api, aws, restapi, nlp, csv, dfs, dl, social, nosql, ml, web, tuktudb, crawler, modeller, viz, dlib)
     .dependsOn(api, aws, restapi, nlp, csv, dfs, dl, social, nosql, ml, web, tuktudb, crawler, modeller, viz, dlib)
+
+scalaVersion := "2.11.8"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,3 +137,17 @@ akka {
         }
     }
 }
+
+# MongoDB Akka
+
+mongo-async-driver {
+    akka {
+        remote {
+            enabled-transports = ["akka.remote.netty.tcp"]
+            netty.tcp {
+                hostname = "127.0.0.1"
+                port = 4711
+            }
+       }
+    }
+}

--- a/modules/modeller/meta/generators/nosql/tuktu.nosql.generators.MongoDBFindGenerator.json
+++ b/modules/modeller/meta/generators/nosql/tuktu.nosql.generators.MongoDBFindGenerator.json
@@ -61,6 +61,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBAggregateProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBAggregateProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBCleanupProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBCleanupProcessor.json
@@ -1,0 +1,23 @@
+{
+	"name": "MongoDB Cleanup Processor",
+	"description": "Closes all MongodB connections.",
+	"class": "tuktu.nosql.processors.mongodb.MongoDBCleanupProcessor",
+	"parameters": [
+		{
+			"name": "id",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "result",
+			"type": "string",
+			"required": true
+		},
+		{
+			"name": "config",
+			"type": "object",
+			"required": true,
+			"parameters": []
+		}
+	]
+}

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBFieldInsertProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBFieldInsertProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBFindProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBFindProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBFindStreamProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBFindStreamProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBInsertProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBInsertProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBRawCommandProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBRawCommandProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBRemoveProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBRemoveProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBUpdateProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBUpdateProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBUpdatumProcessor.json
+++ b/modules/modeller/meta/processors/nosql/mongodb/tuktu.nosql.processors.mongodb.MongoDBUpdatumProcessor.json
@@ -32,6 +32,13 @@
 					]
 				},
 				{
+					"name": "conn",
+					"description": "Number of channels (connections) per node.",
+					"type": "int",
+					"required": false,
+					"default": 10
+				},
+				{
 					"name": "database",
 					"description": "The database name.",
 					"type": "string",

--- a/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbAggregate.scala
+++ b/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbAggregate.scala
@@ -7,28 +7,33 @@ import play.modules.reactivemongo.json.collection._
 import reactivemongo.api._
 import reactivemongo.api.commands.AggregationFramework
 import reactivemongo.core.nodeset.Authenticate
+import scala.collection.immutable.SortedSet
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import tuktu.api._
 import tuktu.nosql.util._
 
 /**
- * Queries MongoDB for data
+ * Aggregate data using the MongoDB aggregation pipeline
  */
-// TODO: Support dynamic querying, is now static
-class MongoDBAggregateProcessor(resultName: String) extends BaseProcessor(resultName) {
-    var settings: MongoSettings = _
+class MongoDBAggregateProcessor(resultName: String) extends BaseProcessor(resultName)
+{
+    var settings: MongoDBSettings = _
     var tasks: List[JsObject] = _
     var user: Option[String] = _
     var pwd: String = _
     var admin: Boolean = _
     var scramsha1: Boolean = _
+    var conn: Int = _
 
-    override def initialize(config: JsObject) {
+    override def initialize(config: JsObject) 
+    {
         // Get hosts, database and collection
-        val hosts = (config \ "hosts").as[List[String]]
+        val hs = (config \ "hosts").as[List[String]]
+        val hosts = SortedSet(hs: _*)
         val database = (config \ "database").as[String]
         val coll = (config \ "collection").as[String]
+        conn = (config \ "connections").asOpt[Int].getOrElse(10)
 
         // Get credentials
         user = (config \ "user").asOpt[String]
@@ -37,33 +42,33 @@ class MongoDBAggregateProcessor(resultName: String) extends BaseProcessor(result
         scramsha1 = (config \ "ScramSha1").asOpt[Boolean].getOrElse(true)
 
         // Prepare connection settings
-        settings = MongoSettings(hosts, database, coll)
+        settings = MongoDBSettings(hosts, database, coll)
 
         // Get aggregation tasks
         tasks = (config \ "tasks").as[List[JsObject]]
     }
 
     override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => {
-        val fcollection: Future[JSONCollection] = user match {
-            case None => MongoTools.getFutureCollection(this, settings)
+        val fcollection = user match {
+            case None => mongoTools.getFutureCollection(settings, conn)
             case Some(usr) => {
                 val credentials = admin match {
                     case true  => Authenticate("admin", usr, pwd)
                     case false => Authenticate(settings.database, usr, pwd)
                 }
-                MongoTools.getFutureCollection(this, settings, credentials, scramsha1)
+                mongoTools.getFutureCollection(settings, credentials, scramsha1, conn)
             }
         }
-        fcollection.flatMap { collection => {
-            import collection.BatchCommands.AggregationFramework.PipelineOperator
-            // Prepare aggregation pipeline
-            val transformer: MongoPipelineTransformer = new MongoPipelineTransformer()(collection)
-            val pipeline: List[PipelineOperator] = tasks.map { x => transformer.json2task(x)(collection=collection) }
-            // Get data from Mongo
-            val resultData: Future[List[JsObject]] = collection.aggregate(pipeline.head, pipeline.tail).map(_.result[JsObject])
-
-            resultData.map { resultList => new DataPacket(for (resultRow <- resultList) yield { tuktu.api.utils.JsObjectToMap(resultRow) }) }
-        }}
-    }) compose Enumeratee.onEOF { () => MongoTools.deleteCollection(this, settings) }
+        val ffdp = fcollection.map{ collection =>
+          import collection.BatchCommands.AggregationFramework.PipelineOperator
+          // Prepare aggregation pipeline
+          val transformer: MongoPipelineTransformer = new MongoPipelineTransformer()(collection)
+          val pipeline: List[PipelineOperator] = tasks.map { x => transformer.json2task(x)(collection=collection) }
+          // Get data from Mongo
+          val resultData: Future[List[JsObject]] = collection.aggregate(pipeline.head, pipeline.tail).map(_.result[JsObject])
+          resultData.map { resultList => new DataPacket(for (resultRow <- resultList) yield { tuktu.api.utils.JsObjectToMap(resultRow) }) }
+        }
+        ffdp.flatMap{ dp => dp}
+    })
 
 }

--- a/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbCleanup.scala
+++ b/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbCleanup.scala
@@ -1,0 +1,28 @@
+package tuktu.nosql.processors.mongodb
+
+import collection.immutable.SortedSet
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import play.api.Play.current
+import play.api.cache.Cache
+import play.api.libs.iteratee.Enumeratee
+import play.api.libs.json._
+import tuktu.api.{ BaseProcessor, DataPacket }
+import tuktu.api.utils.{ MapToJsObject, evaluateTuktuString }
+import reactivemongo.core.nodeset.Authenticate
+import play.modules.reactivemongo.json._
+import scala.concurrent.Future
+import tuktu.nosql.util._
+
+import javax.inject.Inject
+
+/**
+ * Inserts data into MongoDB
+ */
+class MongoDBCleanupProcessor(resultName: String) extends BaseProcessor(resultName) {
+
+      override def initialize(config: JsObject) {}
+
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => Future(data)) compose Enumeratee.onEOF { () => mongoTools.deleteAllCollections }
+}

--- a/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbRawCommand.scala
+++ b/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbRawCommand.scala
@@ -10,6 +10,7 @@ import reactivemongo.api._
 import reactivemongo.api.commands.Command
 import reactivemongo.core.commands.SuccessfulAuthentication
 import reactivemongo.core.nodeset.Authenticate
+import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -19,7 +20,8 @@ import tuktu.api.utils.{ MapToJsObject, evaluateTuktuString }
 /**
  * Provides a helper to run specified database commands (as long as the command result is less than 16MB in size).
  */
-class MongoDBRawCommandProcessor(resultName: String) extends BaseProcessor(resultName) {
+class MongoDBRawCommandProcessor(resultName: String) extends BaseProcessor(resultName)
+{
     var command: String = _
     var db: DefaultDB = _
     var auth: Option[Future[SuccessfulAuthentication]] = _
@@ -83,6 +85,6 @@ class MongoDBRawCommandProcessor(resultName: String) extends BaseProcessor(resul
             }  
         }
         Future.sequence( lfuture ).map{ list => new DataPacket( list ) }
-    }) compose Enumeratee.onEOF { () => connection.close() }
+    })
 
 }

--- a/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbUpdate.scala
+++ b/modules/nosql/app/tuktu/nosql/processors/mongodb/mongodbUpdate.scala
@@ -1,5 +1,6 @@
 package tuktu.nosql.processors.mongodb
 
+import scala.collection.immutable.SortedSet
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import play.api.libs.iteratee.Enumeratee
@@ -9,21 +10,20 @@ import play.modules.reactivemongo.json.collection.JSONCollection
 import reactivemongo.core.nodeset.Authenticate
 import tuktu.api.BaseProcessor
 import tuktu.api.DataPacket
-import tuktu.nosql.util.MongoTools
-import tuktu.nosql.util.MongoSettings
+import tuktu.nosql.util._
 import play.api.cache.Cache
 import play.api.Play.current
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.Await
 import play.api.libs.json._
-import tuktu.nosql.util.stringHandler
 
 /**
  * Updates data into MongoDB
  */
-class MongoDBUpdateProcessor(resultName: String) extends BaseProcessor(resultName) {
+class MongoDBUpdateProcessor(resultName: String) extends BaseProcessor(resultName)
+{
     // the collection to write to and its settings
-    var settings: MongoSettings = _
+    var settings: MongoDBSettings = _
     var fcollection: Future[JSONCollection] = _
     // If set to true, creates a new document when no document matches the query criteria. 
     var upsert = false
@@ -34,10 +34,13 @@ class MongoDBUpdateProcessor(resultName: String) extends BaseProcessor(resultNam
     //  If set to true, updates multiple documents that meet the query criteria. If set to false, updates one document. 
     var multi = false
     var blocking: Boolean = _
+    var conn: Int = _
 
-    override def initialize(config: JsObject) {
+    override def initialize(config: JsObject) 
+    {
         // Set up MongoDB client
-        val hosts = (config \ "hosts").as[List[String]]
+        val hs = (config \ "hosts").as[List[String]]
+        val hosts = SortedSet(hs: _*)
         val database = (config \ "database").as[String]
         val coll = (config \ "collection").as[String]
         query = (config \ "query").as[String]
@@ -45,6 +48,7 @@ class MongoDBUpdateProcessor(resultName: String) extends BaseProcessor(resultNam
         upsert = (config \ "upsert").asOpt[Boolean].getOrElse(false)
         multi = (config \ "multi").asOpt[Boolean].getOrElse(false)
         blocking = (config \ "blocking").asOpt[Boolean].getOrElse(true)
+        conn = (config \ "connections").asOpt[Int].getOrElse(10)
         // Get credentials
         val user = (config \ "user").asOpt[String]
         val pwd = (config \ "password").asOpt[String].getOrElse("")
@@ -52,31 +56,34 @@ class MongoDBUpdateProcessor(resultName: String) extends BaseProcessor(resultNam
         val scramsha1 = (config \ "ScramSha1").asOpt[Boolean].getOrElse(true)
 
         // Set up connection
-        settings = MongoSettings(hosts, database, coll)
+        settings = MongoDBSettings(hosts, database, coll)
         fcollection = user match{
-            case None => MongoTools.getFutureCollection(this, settings)
+            case None => mongoTools.getFutureCollection(settings, conn)
             case Some( usr ) => {
                 val credentials = admin match
                 {
                   case true => Authenticate( "admin", usr, pwd )
                   case false => Authenticate( database, usr, pwd )
                 }
-                MongoTools.getFutureCollection(this, settings,credentials, scramsha1)
+                mongoTools.getFutureCollection(settings,credentials, scramsha1, conn)
               }
           }
     }
 
-    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => if (!blocking) {
-        Future {
-            doUpdate(data)
-            data
+    override def processor(): Enumeratee[DataPacket, DataPacket] = Enumeratee.mapM((data: DataPacket) => {
+        if (!blocking) 
+        {
+            Future {
+                doUpdate(data)
+                data
+            }
+        } else {
+            // Wait for all the updates to be finished
+            doUpdate(data).map {
+                case _ => data
+            }
         }
-    } else {
-        // Wait for all the updates to be finished
-        doUpdate(data).map {
-            case _ => data
-        }
-    }) compose Enumeratee.onEOF { () => MongoTools.deleteCollection(this, settings) }
+    })
     
     
     // Does the actual updating

--- a/modules/nosql/app/tuktu/nosql/util/MongoTools.scala
+++ b/modules/nosql/app/tuktu/nosql/util/MongoTools.scala
@@ -2,6 +2,8 @@ package tuktu.nosql.util
 
 import akka.util.Timeout
 
+import collection.immutable.SortedSet
+
 import play.api.cache.Cache
 import play.api.libs.json._
 import play.api.Play.current
@@ -9,6 +11,7 @@ import play.modules.reactivemongo.json.collection._
 
 import reactivemongo.api.AuthenticationMode
 import reactivemongo.api.CrAuthentication
+import reactivemongo.api.FailoverStrategy
 import reactivemongo.api.MongoConnection
 import reactivemongo.api.MongoConnectionOptions
 import reactivemongo.api.MongoDriver
@@ -16,74 +19,109 @@ import reactivemongo.api.ScramSha1Authentication
 import reactivemongo.core.nodeset.Authenticate
 
 import scala.collection.mutable.HashMap
+import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-object MongoTools 
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+
+
+
+case class MongoDBSettings(hosts: SortedSet[String], database: String, collection: String) 
+
+
+object mongoTools
 {
-    implicit val timeout = Timeout(Cache.getAs[Int]("timeout").getOrElse(5) seconds)
-    
+    implicit val timeout = Timeout(Cache.getAs[Int]("timeout").getOrElse(5) seconds)  
+  
     def typesafeConfig: com.typesafe.config.Config = play.api.libs.concurrent.Akka.system.settings.config
     val driver = new reactivemongo.api.MongoDriver(Some(typesafeConfig))
     
-    val connections = scala.collection.mutable.HashMap[Any,MongoConnection]()
-    val collections = scala.collection.mutable.HashMap[(Any,MongoSettings),Future[JSONCollection]]()
     
-    def getConnection(genproc: Any, hosts: List[String]): MongoConnection = 
+    val connections = scala.collection.mutable.HashMap[SortedSet[String],MongoConnection]()
+    val collections = scala.collection.mutable.HashMap[(MongoDBSettings,String),JSONCollection]()
+    
+    val strategy = FailoverStrategy(
+      initialDelay = 500 milliseconds,
+      retries = 5,
+      delayFactor = attemptNumber => 1 + attemptNumber * 0.5
+    )
+    
+    def getConnection(hosts: SortedSet[String], nbConn: Int): MongoConnection = 
     {
-        connections.getOrElseUpdate(genproc, {
-            driver.connection( hosts )
+        connections.getOrElseUpdate(hosts, {
+            driver.connection( hosts.toList, MongoConnectionOptions( nbChannelsPerNode = nbConn ) )
         })
     }
     
-    def getConnection(genproc: Any, hosts: List[String], scramsha1: Boolean): MongoConnection = 
+    def getConnection(hosts: SortedSet[String], scramsha1: Boolean, nbConn: Int): MongoConnection = 
     {
-        connections.getOrElseUpdate(genproc, {
+        connections.getOrElseUpdate(hosts, {
             val conOpts = scramsha1 match{
-                case true => MongoConnectionOptions( authMode = ScramSha1Authentication )
-                case false => MongoConnectionOptions( authMode = CrAuthentication )
+                case true => MongoConnectionOptions( authMode = ScramSha1Authentication, nbChannelsPerNode = nbConn )
+                case false => MongoConnectionOptions( authMode = CrAuthentication, nbChannelsPerNode = nbConn )
             }
-            driver.connection(hosts, options = conOpts)
+            driver.connection(hosts.toList, options = conOpts)
         })
     }
     
     
-    def closeConnection(genproc: Any) =
+    def closeConnection(hosts: SortedSet[String]) =
     {
-        connections.remove( genproc ) match {
+       connections.remove( hosts ) match {
             case Some( connection ) => connection.close()
+       }
+    }
+    
+    
+    def getFutureCollection( settings: MongoDBSettings, nbChannelsPerNode: Int ): Future[JSONCollection] =
+    {
+        collections.get(settings,"") match{
+          case Some(coll) => Future(coll)
+          case None => {
+            val connection = getConnection(settings.hosts, nbChannelsPerNode)
+            val fdb = connection.database(settings.database, strategy)
+            val fcoll = fdb.map(_.collection(settings.collection, strategy))
+            fcoll.map{ coll => collections.put((settings,""), coll) }
+            fcoll
+          }
         }
     }
     
-    def getFutureCollection( genproc: Any, settings: MongoSettings ): Future[JSONCollection] =
+    def getFutureCollection( settings: MongoDBSettings, credentials: Authenticate, scramsha1: Boolean, nbChannelsPerNode: Int ): Future[JSONCollection] =
     {
-        collections.getOrElseUpdate( (genproc,settings), {
-            Future{
-                val connection = getConnection(genproc, settings.hosts)
-                val db = connection(settings.database)
-                db(settings.collection)
-            }
-        })
-    }
-    
-    def getFutureCollection( genproc: Any, settings: MongoSettings, credentials: Authenticate, scramsha1: Boolean ): Future[JSONCollection] =
-    {
-        collections.getOrElseUpdate( (genproc,settings), {
-            val connection = getConnection(genproc, settings.hosts, scramsha1)
+        collections.get((settings,credentials.user)) match {
+        case Some(coll) => Future(coll)
+        case None => {
+            val connection = getConnection(settings.hosts, scramsha1, nbChannelsPerNode)
+            val fdb = connection.database(settings.database, strategy)
             // Authenticate
-            val db = connection(settings.database)
-            val auth = (credentials.db.equals( settings.database )) match {
-                case true => db.authenticate(credentials.user, credentials.password)(timeout.duration)
-                case false => val authdb = connection(credentials.db) ; authdb.authenticate(credentials.user, credentials.password)(timeout.duration)
-            }
-            auth.map { _ => db(settings.collection) }
-        })
+            val authdb = connection(credentials.db, strategy)
+            val fauth = authdb.authenticate(credentials.user, credentials.password)(timeout.duration)
+            //Thread.sleep(5000)
+            val fcoll = fauth.flatMap{ auth => fdb.map{ db => db.collection(settings.collection, strategy) }}
+            // store authenticated collection for future use 
+            fcoll.map{ coll => collections.put((settings, credentials.user), coll) }
+            fcoll
+        }}
     }
     
-    def deleteCollection( genproc: Any, settings: MongoSettings ) =
+    def deleteAllCollections =
     {
-        collections.remove( (genproc, settings) ) 
-        closeConnection(genproc)
+        collections.map( f => deleteCollectionForUser(f._1._1, f._1._2) )
+    }
+    
+    def deleteCollection( settings: MongoDBSettings ) =
+    {
+        collections.remove( settings,"" ) 
+        closeConnection( settings.hosts )
+    }
+    
+    def deleteCollectionForUser( settings: MongoDBSettings, user: String ) =
+    {
+        collections.remove( (settings, user) ) 
+        closeConnection( settings.hosts )
     }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.10")
 
 // web plugins
 


### PR DESCRIPTION
Hi Erik and all,

This is a rewrite of the mongodb part of the nosql module.  It is not perfect but solves a series of authentication issues:

reactivemongo 0.11.7 had a bug that prevented to use asynchronous authentication (the successful authentication future was successful before authentication completed) this is fixed in reactivemongo 0.11.11, which, in addition, supports MongoDB 3.2

it is now possible to manage collections opened by different users (to whom different privileges are granted)

Note that it seems that, contrary to reactivemongo 0.11.7, version 0.11.11 reuses tuktu's Akka port and conflicts with it, so, it was necessary to add a dedicated section "mongo-async-driver" in application.conf to specify an alternative port.

What do you think?

David
