### PR TITLE
ReactiveMongo 0.11.13 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val nosqlDependencies = Seq(
     "org.postgresql" % "postgresql" % "9.3-1102-jdbc41",
     "org.xerial" % "sqlite-jdbc" % "3.8.7",
     "org.apache.kafka" %% "kafka" % "0.8.2-beta",
-    "org.reactivemongo" %% "play2-reactivemongo" % "0.11.11-play23",
+    "org.reactivemongo" %% "play2-reactivemongo" % "0.11.13-play23",
     "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.4",
     "org.elasticsearch" % "elasticsearch" % "1.4.4",
     "org.apache.hadoop" % "hadoop-client" % "2.6.0",


### PR DESCRIPTION
ReactiveMongo 0.11.11 uses a version of Ning that conflicts with play ws (and breaks multiple processors and generators).  This is fixed by upgrading to reactivemongo 0.11.13.
