### PR TITLE
Create new connections for each new collection/user.

### DIFF
--- a/modules/nosql/app/tuktu/nosql/util/MongoTools.scala
+++ b/modules/nosql/app/tuktu/nosql/util/MongoTools.scala
@@ -51,20 +51,20 @@ object mongoTools
     
     def getConnection(hosts: SortedSet[String], nbConn: Int): MongoConnection = 
     {
-        connections.getOrElseUpdate(hosts, {
-            driver.connection( hosts.toList, MongoConnectionOptions( nbChannelsPerNode = nbConn ) )
-        })
+        val conns = driver.connection( hosts.toList, MongoConnectionOptions( nbChannelsPerNode = nbConn ) )
+        connections.put(hosts, conns)
+        conns
     }
     
     def getConnection(hosts: SortedSet[String], scramsha1: Boolean, nbConn: Int): MongoConnection = 
     {
-        connections.getOrElseUpdate(hosts, {
-            val conOpts = scramsha1 match{
-                case true => MongoConnectionOptions( authMode = ScramSha1Authentication, nbChannelsPerNode = nbConn )
-                case false => MongoConnectionOptions( authMode = CrAuthentication, nbChannelsPerNode = nbConn )
-            }
-            driver.connection(hosts.toList, options = conOpts)
-        })
+        val conOpts = scramsha1 match{
+          case true => MongoConnectionOptions( authMode = ScramSha1Authentication, nbChannelsPerNode = nbConn )
+          case false => MongoConnectionOptions( authMode = CrAuthentication, nbChannelsPerNode = nbConn )
+        }
+        val conns = driver.connection(hosts.toList, options = conOpts)
+        connections.put(hosts, conns)
+        conns
     }
     
     


### PR DESCRIPTION
Fixes issue #33 by creating a new connection pool for each new collection/user.
Note that, as there is no way to detect when a collection is not used anymore (cf. issue #29), it is necessary to schedule a job for explicitly close collections and connections when tuktu runs for a long period of time.  This can be done using the MongoDB Cleanup processor.
