### PR TITLE
TuktuJS rework

### DIFF
--- a/app/views/cluster/overview.scala.html
+++ b/app/views/cluster/overview.scala.html
@@ -72,14 +72,6 @@
 	        <div class="row">
 	            <div class="col-xs-12">
 	                <div class="form-group">
-	                    <label for="jsurl">Tuktu JS File Name</label>
-	                    <input type="text" class="form-control" id="jsurl" name="jsurl" value="@{params.get("jsurl").getOrElse("")}">
-	                </div>
-	            </div>
-	        </div>
-	        <div class="row">
-	            <div class="col-xs-12">
-	                <div class="form-group">
 	                    <label for="jsname">JS DataPacket Field Name</label>
 	                    <input type="text" class="form-control" id="jsname" name="jsname" value="@{params.get("jsname").getOrElse("")}">
 	                </div>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -18,7 +18,7 @@
         <title>Tuktu&reg; - Big Data Made Easy</title>
     </head>
 
-    <body><script async src=@{Play.current.configuration.getString("tuktu.url").get + Play.current.configuration.getString("tuktu.jsurl").get}></script>
+    <body>
         <nav class="navbar navbar-fixed-top">
             <div class="container">
                 <div class="navbar-header">

--- a/app/views/monitor/showConfigs.scala.html
+++ b/app/views/monitor/showConfigs.scala.html
@@ -1,207 +1,208 @@
 @(path: Seq[String], configs: collection.mutable.Buffer[String], folders: collection.mutable.Buffer[String])
-    <div class="row" style="margin-bottom: 20px; border-bottom: 1px solid #333;">
-       <div class="col-xs-11">
-           <a href="#" onClick="navigateFolder('')">[root]</a>
-               @for((elem, index) <- path.zipWithIndex) { / <a href="#" onClick="navigateFolder('@path.take(index).mkString("/")/@elem')">@elem</a> }
+
+<div class="row" style="margin-bottom: 20px; border-bottom: 1px solid #333;">
+   <div class="col-xs-11">
+       <a href="#" onClick="navigateFolder('')">[root]</a>
+           @for((elem, index) <- path.zipWithIndex) { / <a href="#" onClick="navigateFolder('@path.take(index).mkString("/")/@elem')">@elem</a> }
+    </div>
+    <div class="col-xs-1 pull-right">
+        <a href="#" onClick="createNew(false)">
+            <span aria-hidden="true" class="glyphicon glyphicon-plus"></span>
+            New File
+        </a>
+        <br>
+        <a href="#" data-toggle="modal" data-target="#uploadModal">
+            <span aria-hidden="true" class="glyphicon glyphicon-upload"></span>
+            Upload File
+        </a>
+
+        <div class="modal fade" id="uploadModal" tabindex="-1" role="dialog" aria-labelledby="uploadModalLabel">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <form action="@routes.Monitor.uploadFile" method="post" enctype="multipart/form-data">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title" id="uploadModalLabel">Upload Tuktu Config File</h4>
+                        </div>
+                        <div class="modal-body">
+                            <div class="form-group">
+                                <input type="file" name="fileName" id="configFileName" required>
+                                <input type="hidden" name="path" value="@{path.mkString("/")}">
+                                <p class="help-block">Select the JSON Tuktu config file to upload.</p>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                            <button type="submit" class="btn btn-primary">Upload</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <div class="col-xs-1 pull-right">
-            <a href="#" onClick="createNew(false)">
-                <span aria-hidden="true" class="glyphicon glyphicon-plus"></span>
-                New File
-            </a>
-            <br>
-			<a href="#" data-toggle="modal" data-target="#uploadModal">
-			    <span aria-hidden="true" class="glyphicon glyphicon-upload"></span>
-                Upload File
-			</a>
-			
-			<div class="modal fade" id="uploadModal" tabindex="-1" role="dialog" aria-labelledby="uploadModalLabel">
-			  <div class="modal-dialog" role="document">
-			    <div class="modal-content">
-			        <form action="@routes.Monitor.uploadFile" method="post" enctype="multipart/form-data">
-					      <div class="modal-header">
-					        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-					        <h4 class="modal-title" id="uploadModalLabel">Upload Tuktu Config File</h4>
-					      </div>
-					      <div class="modal-body">
-					        <div class="form-group">
-				                <input type="file" name="fileName" id="configFileName" required>
-				                <input type="hidden" name="path" value="@{path.mkString("/")}">
-				                <p class="help-block">Select the JSON Tuktu config file to upload.</p>
-				            </div>
-					      </div>
-					      <div class="modal-footer">
-					        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-					        <button type="submit" class="btn btn-primary">Upload</button>
-					      </div>
-					</form>
-			    </div>
-			  </div>
-			</div>
-            
-            <br>
-            <a href="#" onClick="createNew(true)">
-                <span aria-hidden="true" class="glyphicon glyphicon-plus"></span>
-                New Folder
+
+        <br>
+        <a href="#" onClick="createNew(true)">
+            <span aria-hidden="true" class="glyphicon glyphicon-plus"></span>
+            New Folder
+        </a>
+    </div>
+</div>
+
+@for(folder <- folders) {
+    <div class="row">
+        <div class="col-xs-12">
+            <a href="#" onClick="navigateFolder('@path.mkString("/")/@folder')">
+                <span aria-hidden="true" class="glyphicon glyphicon-folder-open"></span>
+                &nbsp;
+                @folder
             </a>
         </div>
     </div>
+}
 
-    @for(folder <- folders) {
-        <div class="row">
-            <div class="col-xs-12">
-                <a href="#" onClick="navigateFolder('@path.mkString("/")/@folder')">
-                    <span aria-hidden="true" class="glyphicon glyphicon-folder-open"></span>
+@if(!folders.isEmpty) { <hr> }
+
+@if(!configs.isEmpty) {
+    <div class="row" style="margin-bottom: 20px;">
+        <input type="submit" class="btn btn-xs btn-info" value="Start Selected" onClick="batchStarter()">
+    </div>
+
+    <table class="table table-hover" id="configTable">
+        @for((config, idx) <- configs.zipWithIndex) {
+            <tr>
+               <td width="20px">
+                   <input type="checkbox" value="@{(path :+ config).mkString("/")}">
+               </td>
+                <td>
+                    <span aria-hidden="true" class="glyphicon glyphicon-file"> </span>
                     &nbsp;
-                    @folder
-                </a>
-            </div>
-        </div>
+                    <span id="jobName_@idx" onclick="renameInitiate('jobName_@idx', '@{(path :+ config).mkString("/")}', '@config')">@config</span>
+                </td>
+                <td width="10%">
+                    <form method="post" action="@routes.Monitor.startJob">
+                        <input name="name" type="text" class="hidden" value="@{(path :+ config).mkString("/")}"/>
+                        <input type="submit" class="btn btn-xs" value="Start Job">
+                    </form>
+                </td>
+                <td width="10%">
+                    <a href="@controllers.modeller.routes.Application.index((path :+ config + ".json").mkString("/"))">Edit Config</a>
+                </td>
+                <td width="10%">
+                    <a href="#" onClick="deleteFile('@{(path :+ config + ".json").mkString("/")}', '@config')" class="pull-right">
+                        <span aria-hidden="true" class="glyphicon glyphicon-trash"></span>
+                    </a>
+                </td>
+            </tr>
+        }
+    </table>
+
+    <div class="row">
+       <input type="submit" class="btn btn-xs btn-info" value="Start Selected" onClick="batchStarter()">
+    </div>
+}
+
+<script type="text/javascript">
+    function renameInitiate(elem, path, name) {
+        $("#" + elem).removeAttr('onclick');
+        $("#" + elem).html("<input type='text' value='" + name + "' onblur='renameComplete(\"" + elem + "\", this, \"" + path + "\", \"" + name + "\")'>");
     }
 
-    @if(!folders.isEmpty) { <hr> }
+    function renameComplete(parent, elem, oldPath, oldName) {
+        var newName = $(elem).val();
+        console.log($('#' + parent));
 
-    @if(!configs.isEmpty) {
-        <div class="row" style="margin-bottom: 20px;">
-            <input type="submit" class="btn btn-xs btn-info" value="Start Selected" onClick="batchStarter()">
-        </div>
-        
-        <table class="table table-hover" id="configTable">
-            @for((config, idx) <- configs.zipWithIndex) {
-                <tr>
-                   <td width="20px">
-                       <input type="checkbox" value="@path.mkString("/")/@config">
-                   </td>
-                    <td>
-                        <span aria-hidden="true" class="glyphicon glyphicon-file"> </span>
-                        &nbsp;
-                        <span id="jobName_@idx" onclick="renameInitiate('jobName_@idx', '@path.mkString("/")/@config', '@config')">@config</span>
-                    </td>
-                    <td width="10%">
-                        <form method="post" action="@routes.Monitor.startJob">
-                            <input name="name" type="text" class="hidden" value="@path.mkString("/")/@config"/>
-                            <input type="submit" class="btn btn-xs" value="Start Job">
-                        </form>
-                    </td>
-                    <td width="10%">
-                        <a href="@controllers.modeller.routes.Application.index((path :+ config + ".json").mkString("/"))">Edit Config</a>
-                    </td>
-                    <td width="10%">
-                        <a href="#" onClick="deleteFile('@{(path :+ config + ".json").mkString("/")}', '@config')" class="pull-right">
-                            <span aria-hidden="true" class="glyphicon glyphicon-trash"></span>
-                        </a>
-                    </td>
-                </tr>
+        $.ajax({
+            method : "POST",
+            url : "@routes.Monitor.rename",
+            data : {
+                old : oldPath,
+                new: newName
+            },
+            success: function() {
+                var arr = oldPath.split("/");
+                arr.pop();
+                var newPath = arr.join("/") + "/" + newName;
+
+                $("#" + parent).attr('onclick', "renameInitiate('" + parent + "', '" + newPath + "', '" + newName + "')");
+                $("#" + parent).html(newName);
+            },
+            error: function() {
+                $("#" + parent).attr('onclick', "renameInitiate('" + parent + "', '" + oldPath + "', '" + oldName + "')");
+                $("#" + parent).html(oldName);
             }
-        </table>
-        
-        <div class="row">
-           <input type="submit" class="btn btn-xs btn-info" value="Start Selected" onClick="batchStarter()">
-        </div>
+        });
     }
 
-    <script type="text/javascript">
-        function renameInitiate(elem, path, name) {
-            $("#" + elem).removeAttr('onclick');
-            $("#" + elem).html("<input type='text' value='" + name + "' onblur='renameComplete(\"" + elem + "\", this, \"" + path + "\", \"" + name + "\")'>");
-        }
-        
-        function renameComplete(parent, elem, oldPath, oldName) {
-            var newName = $(elem).val();
-            console.log($('#' + parent));
-            
+    function navigateFolder(folder) {
+        $.ajax({
+            method : "POST",
+            url : "@routes.Monitor.showConfigs",
+            data : {
+                path : folder
+            }
+        }).done(function(html) {
+            updateFormDiv(html);
+        });
+    }
+
+    function createNew(isFolder) {
+        var filename = "";
+        if (isFolder) {
+            filename = prompt("Please enter the name of the folder.", "NewFolder");
             $.ajax({
                 method : "POST",
-                url : "@routes.Monitor.rename",
+                url : "@routes.Monitor.newDirectory",
                 data : {
-                    old : oldPath,
-                    new: newName
-                },
-                success: function() {
-                    var arr = oldPath.split("/");
-                    arr.pop();
-                    var newPath = arr.join("/") + "/" + newName;
-                    
-                    $("#" + parent).attr('onclick', "renameInitiate('" + parent + "', '" + newPath + "', '" + newName + "')");
-                    $("#" + parent).html(newName);
-                },
-                error: function() {
-                    $("#" + parent).attr('onclick', "renameInitiate('" + parent + "', '" + oldPath + "', '" + oldName + "')");
-                    $("#" + parent).html(oldName);
-                }
-            });
-        }
-    
-        function navigateFolder(folder) {
-            $.ajax({
-                method : "POST",
-                url : "@routes.Monitor.showConfigs",
-                data : {
-                    path : folder
+                    path: @if(path.nonEmpty) {"@path.mkString("/")/" +} filename
                 }
             }).done(function(html) {
-                updateFormDiv(html);
+                navigateFolder("@path.mkString("/")");
             });
         }
-        
-        function createNew(isFolder) {
-            var filename = "";
-            if (isFolder) {
-                filename = prompt("Please enter the name of the folder.", "NewFolder");
-                $.ajax({
-                    method : "POST",
-                    url : "@routes.Monitor.newDirectory",
-                    data : {
-                        path: "@path.mkString("/")/" + filename
-                    }
-                }).done(function(html) {
-                    navigateFolder("@path.mkString("/")");
-                });
-            }
-            else {
-                filename = prompt("Please enter the name of the file.", "NewFile");
-                $.ajax({
-                    method : "POST",
-                    url : "@routes.Monitor.newFile",
-                    data : {
-                        file: "@path.mkString("/")/" + filename
-                    }
-                }).done(function(html) {
-                    navigateFolder("@path.mkString("/")");
-                });
-            }
+        else {
+            filename = prompt("Please enter the name of the file.", "NewFile");
+            $.ajax({
+                method : "POST",
+                url : "@routes.Monitor.newFile",
+                data : {
+                    file: @if(path.nonEmpty) {"@path.mkString("/")/" +} filename
+                }
+            }).done(function(html) {
+                navigateFolder("@path.mkString("/")");
+            });
         }
-        
-        function deleteFile(filename, shortname) {
-            var c = confirm("Are you sure you want to delete " + shortname + "?");
-            if (c == true) {
-                $.ajax({
-                    method : "POST",
-                    url : "@routes.Monitor.deleteFile",
-                    data : {
-                        file: filename
-                    }
-                }).done(function(html) {
-                    navigateFolder("@path.mkString("/")");
-                });
-            }
-        }
-        
-        function batchStarter() {
-            var configs = $("#configTable input:checkbox:checked").map(function(){
-                return $(this).val();
-            }).get();
+    }
 
-            if (configs.length > 0) {
-                $.ajax({
-                    method : "POST",
-                    url : "@routes.Monitor.batchStarter",
-                    data : {
-                        jobs: configs.join(",")
-                    }
-                }).done(function(html) {
-                    window.location = '@routes.Monitor.fetchLocalInfo(1, 1)';
-                });
-            }
+    function deleteFile(filename, shortname) {
+        var c = confirm("Are you sure you want to delete " + shortname + "?");
+        if (c == true) {
+            $.ajax({
+                method : "POST",
+                url : "@routes.Monitor.deleteFile",
+                data : {
+                    file: filename
+                }
+            }).done(function(html) {
+                navigateFolder("@path.mkString("/")");
+            });
         }
-    </script>
+    }
+
+    function batchStarter() {
+        var configs = $("#configTable input:checkbox:checked").map(function(){
+            return $(this).val();
+        }).get();
+
+        if (configs.length > 0) {
+            $.ajax({
+                method : "POST",
+                url : "@routes.Monitor.batchStarter",
+                data : {
+                    jobs: configs.join(",")
+                }
+            }).done(function(html) {
+                window.location = '@routes.Monitor.fetchLocalInfo(1, 1)';
+            });
+        }
+    }
+</script>

--- a/app/views/scheduler/showConfigs.scala.html
+++ b/app/views/scheduler/showConfigs.scala.html
@@ -11,7 +11,7 @@
     @for(folder <- folders) {
         <div class="row">
             <div class="col-xs-12">
-                <a href="#" onClick="navigateFolder('@path.mkString("/")/@folder')">
+                <a href="#" onClick="navigateFolder('@{(path :+ folder).mkString("/")}')">
                     <span aria-hidden="true" class="glyphicon glyphicon-folder-open"></span>
                     &nbsp;
                     @folder
@@ -27,7 +27,7 @@
             @for((config, index) <- configs.zipWithIndex) {
                 <tr>
                    <td width="20px">
-                       <input type="checkbox" value="@path.mkString("/")/@config" name="jobs[@index]" value="@path.mkString("/")/@config">
+                       <input type="checkbox" value="@{(path :+ config).mkString("/")}" name="jobs[@index]">
                    </td>
                     <td>
                         <span aria-hidden="true" class="glyphicon glyphicon-file"> </span>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,11 +59,10 @@ logger.application=DEBUG
 
 
 tuktu {
-    url = "http://localhost:9000/"
+    url = "http://localhost:9000"
     metarepo = "modules/modeller/meta"
     configrepo = "configs"
     webrepo = "configs/analytics"
-    jsurl = "Tuktu.js"
     jsname = "tuktu_js_field"
     timeout = 30
     dispatchers = 5
@@ -113,9 +112,10 @@ tuktu {
 		set_id_cookies = true
 	}
 	tests = [
-		"tuktu.test.processor.tests.BaseProcessorTestSuite",
-		"tuktu.test.processor.tests.BufferProcessorTestSuite",
-		"tuktu.test.flow.tests.FlowTests",
+		#"tuktu.test.processor.tests.BaseProcessorTestSuite",
+		#"tuktu.test.processor.tests.BufferProcessorTestSuite",
+		"tuktu.test.cemistry.CEMistryTestSuite",
+		#"tuktu.test.flow.tests.FlowTests",
 		"tuktu.test.api.utilsTests",
 		"tuktu.test.api.ParsingTests"
 	]

--- a/conf/routes
+++ b/conf/routes
@@ -62,11 +62,7 @@ GET     /dbw/browser                        controllers.DBWrapper.index
 ->      /db                                 db.Routes
 
 # Web
-GET     /Tuktu.js/:id                       controllers.web.Application.TuktuJsGet(id)
-GET     /Tuktu.js                           controllers.web.Application.TuktuJs
-POST    /Tuktu.js/:id                       controllers.web.Application.webGet(id)
-POST    /Tuktu.js                           controllers.web.Application.web
-GET     /Tuktu.gif/:id                      controllers.web.Application.imgGet(id)
+->      /web                                web.Routes
 
 # API
 ->      /api/v1                             restapi.Routes

--- a/modules/api/app/tuktu/api/scheduler/TuktuScheduler.scala
+++ b/modules/api/app/tuktu/api/scheduler/TuktuScheduler.scala
@@ -15,7 +15,6 @@ import play.api.Play.current
 import play.api.cache.Cache
 import play.api.libs.concurrent.Akka
 import tuktu.api.DispatchRequest
-import tuktu.api.DispatchRequest
 
 case class DelayedScheduler(
         name: String,

--- a/modules/api/app/tuktu/api/utils.scala
+++ b/modules/api/app/tuktu/api/utils.scala
@@ -1,6 +1,6 @@
 package tuktu.api
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{ Files, Paths, Path }
 import java.util.Date
 import scala.util.Try
 import scala.util.hashing.MurmurHash3
@@ -387,10 +387,12 @@ object utils {
     /**
      * Loads a config from the config folder
      */
-    def loadConfig(name: String): Try[JsObject] = Try {
-        val path = Paths.get(
-            Cache.getAs[String]("configRepo").getOrElse("configs"),
-            name + { if (name.endsWith(".json")) "" else ".json" })
+    def loadConfig(path: Path): Try[JsObject] = Try {
         Json.parse(Files.readAllBytes(path)).as[JsObject]
     }
+    def loadConfig(name: String): Try[JsObject] = Try {
+        Paths.get(
+            Cache.getAs[String]("configRepo").getOrElse("configs"),
+            name + { if (name.endsWith(".json")) "" else ".json" })
+    }.flatMap(loadConfig)
 }

--- a/modules/api/app/tuktu/api/web.scala
+++ b/modules/api/app/tuktu/api/web.scala
@@ -41,7 +41,6 @@ case class WebJsOrderedObject(
 ) extends BaseJsObject()
 
 abstract class TuktuBaseJSGenerator(
-        referer: String,
         resultName: String,
         processors: List[Enumeratee[DataPacket, DataPacket]],
         senderActor: Option[ActorRef]

--- a/modules/web/app/controllers/Application.scala
+++ b/modules/web/app/controllers/Application.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorRef
 import java.net.URL
 import java.nio.file._
 import play.api.cache.Cache
+import play.api._
 import play.api.Play
 import play.api.Play.current
 import play.api.mvc._
@@ -25,172 +26,80 @@ import tuktu.api.ErrorPacket
 import tuktu.api.RequestPacket
 
 object Application extends Controller {
-    val source = scala.io.Source.fromFile(Play.application.getFile("public/images/pixel.gif"))(scala.io.Codec.ISO8859)
-    val byteArray = source.map(_.toByte).toArray
-    source.close()
+    val byteArray = Files.readAllBytes(Paths.get("public", "images", "pixel.gif"))
+
+    /**
+     * Creates tracking cookies if web.set_cookies is true and they aren't set yet
+     */
+    def cookies(implicit request: Request[AnyContent]): List[Cookie] =
+        if (Cache.getAs[Boolean]("web.set_cookies").getOrElse(true))
+            List(
+                request.cookies.get("t_s_id") match {
+                    case None => Some(Cookie("t_s_id", java.util.UUID.randomUUID.toString))
+                    case _    => None
+                },
+                request.cookies.get("t_u_id") match {
+                    case None => Some(Cookie("t_u_id", java.util.UUID.randomUUID.toString, Some(Int.MaxValue)))
+                    case _    => None
+                }).flatten
+        else Nil
 
     /**
      * Handles a polymorphic JS-request
      */
-    def handleRequest(idOption: Option[String], referer: Option[String], request: Request[AnyContent],
-            isInitial: Boolean, image: Boolean = false): Future[Result] = {
-        if (idOption.isEmpty && referer.isEmpty)
-            Future {
-                if (image)
-                    Ok(byteArray).as("image/gif")
-                else
-                    BadRequest("// No referrer found in HTTP headers.")
-            }
-        else {
-            val id = idOption.getOrElse(referer.get)
-            Cache.getAs[String]("web.repo") match {
-                case None => Future {
-                    if (image)
-                        Ok(byteArray).as("image/gif")
-                    else
-                        BadRequest("// No repository for JavaScripts and Tuktu flows set in Tuktu configuration.")
+    def handleRequest(id: String, isGET: Boolean)(implicit request: Request[AnyContent]): Future[Result] =
+        // Try to get actual actor from hostmap
+        Cache.getAs[collection.mutable.Map[String, ActorRef]]("web.hostmap").flatMap { _.get(id) } match {
+            case None => Future { BadRequest("// The analytics script is not enabled.") }
+            case Some(actorRef) =>
+                implicit val timeout = Timeout(Cache.getAs[Int]("timeout").getOrElse(5) seconds)
+
+                // Forward request and handle result
+                (actorRef ? RequestPacket(request, isGET)).map {
+                    case dp: DataPacket =>
+                        // Get all the JS elements and output them one after the other
+                        val jsResult = JSGeneration.PacketToJsBuilder(dp)
+                        Ok(views.js.Tuktu(jsResult._2, jsResult._1,
+                            Cache.getOrElse[String]("web.url")("http://localhost:9000") + routes.Application.TuktuJsPost(id).url,
+                            jsResult._3))
+                            .withCookies(cookies: _*)
+                    case error: ErrorPacket =>
+                        BadRequest("// Internal error occured.")
+                    case _ =>
+                        // Return blank
+                        Ok("").as("text/javascript")
                 }
-                case Some(webRepo) => {
-
-                    
-                    // Get actual actor
-                    val actorRefMap = Cache.getAs[collection.mutable.Map[String, ActorRef]]("web.hostmap")
-                        .getOrElse(collection.mutable.Map[String, ActorRef]())
-
-                    // Check if JS actor is running
-                    if (!actorRefMap.contains(id))
-                        Future {
-                            if (image)
-                                Ok(byteArray).as("image/gif")
-                            else
-                                BadRequest("// The analytics script is not enabled.")
-                        }
-                    else {
-                        implicit val timeout = Timeout(Cache.getAs[Int]("timeout").getOrElse(5) seconds)
-
-                        // See if we need to start a new flow or if we can send to the running actor
-                        val resultFut = if (isInitial) {
-                            // Send the Actor a DataPacket
-                            val actorRef = actorRefMap(id)
-                            
-                            if (image) {
-                                actorRef ! RequestPacket(request, isInitial)
-                                Future {}
-                            }
-                            else
-                                actorRef ? RequestPacket(request, isInitial)
-                        } else {
-                            // Since this is not the default flow, we have to see if this one is running, and start
-                            // if if this is not the case
-
-                            // Flow name must be set
-                            (request.body.asJson.getOrElse(Json.obj()).asInstanceOf[JsObject] \"f").asOpt[String] match {
-                                case None => {
-                                    // Flow name is gone, this can't be
-                                    Future {}
-                                }
-                                case Some(fn) => {
-                                    // See if the flow for this one is already running
-                                    if (!actorRefMap.contains(id + "." + fn)) {
-                                        // Dispatch new config
-                                        val fut = Akka.system.actorSelection("user/TuktuDispatcher") ?
-                                            new DispatchRequest(
-                                                webRepo.drop(Play.current.configuration.getString("tuktu.configrepo").getOrElse("configs").size)
-                                                    + "/" + id + "/" + fn, None, false, true, false, None)
-                                        // We must wait here
-                                        val actorRef = Await.result(fut, timeout.duration).asInstanceOf[ActorRef]
-                                        // Add to our map
-                                        Cache.getAs[collection.mutable.Map[String, ActorRef]]("web.hostmap")
-                                            .getOrElse(collection.mutable.Map[String, ActorRef]()) +=
-                                            (id + "." + fn -> actorRef)
-                                    }
-
-                                    // Send the Actor a DataPacket containing the referrer
-                                    actorRefMap(id + "." + fn) ? RequestPacket(request, isInitial)
-                                }
-                            }
-                        }
-                        
-                        // Check if we need to add session/user ID or not
-                        val cookies = (request.cookies.get("t_s_id") match {
-                            case None if (Cache.getAs[Boolean]("web.set_cookies").getOrElse(true)) =>
-                                List(Cookie("t_s_id", java.util.UUID.randomUUID.toString))
-                            case _ => List()
-                        }) ++ (request.cookies.get("t_u_id") match {
-                            case None if (Cache.getAs[Boolean]("web.set_cookies").getOrElse(true)) =>
-                                List(Cookie("t_u_id", java.util.UUID.randomUUID.toString, Some(Int.MaxValue)))
-                            case _ => List()
-                        })
-
-                        // Return result
-                        if (image) Future { Ok(byteArray).as("image/gif").withCookies(cookies: _*) }
-                        else resultFut.map {
-                            case dp: DataPacket =>
-                                // Get all the JS elements and output them one after the other
-                                val jsResult = JSGeneration.PacketToJsBuilder(dp)
-                                Ok(views.js.Tuktu(jsResult._2, jsResult._1,
-                                    Cache.getAs[String]("web.url").getOrElse("http://localhost:9000/") +
-                                    Cache.getAs[String]("web.jsurl").getOrElse("Tuktu.js") + idOption.map('/' + _).getOrElse(""),
-                                    jsResult._3))
-                                .withCookies(cookies: _*)
-                            case error: ErrorPacket =>
-                                BadRequest("Internal error occured")
-                            case _ =>
-                                // Return blank
-                                Ok("").as("text/javascript")
-                        }
-                    }
-                }
-            }
         }
-    }
-
-    /**
-     * Loads a JavaScript analytics script depending on referrer
-     */
-    def TuktuJs = Action.async { implicit request =>
-        handleRequest(None, request.headers.get("referer") match {
-            case None => None
-            case Some(ref) => Some({
-                val host = new URL(ref).getHost
-                if (host.startsWith("www.")) host.drop("www.".length)
-                else host
-            })
-        }, request, true)
-    }
 
     /**
      * Invoke a flow based on a GET parameter that serves as ID
      */
     def TuktuJsGet(id: String) = Action.async { implicit request =>
-        handleRequest(Some(id), None, request, true)
-    }
-
-    /**
-     * Handles analytics by referrer
-     */
-    def web = Action.async { implicit request =>
-        handleRequest(None, request.headers.get("referer") match {
-            case None => None
-            case Some(ref) => Some({
-                val host = new URL(ref).getHost
-                if (host.startsWith("www.")) host.drop("www.".length)
-                else host
-            })
-        }, request, false)
+        handleRequest(id, true)
     }
 
     /**
      * Handles analytics by id
      */
-    def webGet(id: String) = Action.async { implicit request =>
-        handleRequest(Some(id), None, request, false)
+    def TuktuJsPost(id: String) = Action.async { implicit request =>
+        handleRequest(id, false)
     }
-    
+
     /**
      * Serves an image instead of some JS
      */
     def imgGet(id: String) = Action.async { implicit request =>
-        handleRequest(Some(id), None, request, true, true)
+        Future {
+            // Try to get actual actor from hostmap
+            Cache.getAs[collection.mutable.Map[String, ActorRef]]("web.hostmap").flatMap { _.get(id) } match {
+                case None => Ok(byteArray).as("image/gif")
+                case Some(actorRef) =>
+                    // Send the Actor a DataPacket
+                    actorRef ! RequestPacket(request, true)
+
+                    // Return result
+                    Ok(byteArray).as("image/gif").withCookies(cookies: _*)
+            }
+        }
     }
 }

--- a/modules/web/app/globals/WebGlobal.scala
+++ b/modules/web/app/globals/WebGlobal.scala
@@ -1,82 +1,34 @@
 package globals
 
-import tuktu.api.TuktuGlobal
+import java.nio.file.{ Files, Path, Paths }
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.util.Failure
+
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.util.Timeout
 import play.api.Application
 import play.api.Play
-import java.io.File
-import tuktu.api.DispatchRequest
-import play.api.libs.concurrent.Akka
 import play.api.Play.current
-import akka.pattern.ask
-import scala.concurrent.Future
-import akka.actor.ActorRef
 import play.api.cache.Cache
-import akka.util.Timeout
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Await
-import tuktu.api.ClusterNode
-import play.api.Logger
-import java.util.concurrent.TimeoutException
+import play.api.libs.concurrent.Akka
+import tuktu.api.{ ClusterNode, DispatchRequest, TuktuGlobal }
 
 /**
  * Loops through the web analytics configs and boots up instances of the flows present there
  */
 class WebGlobal() extends TuktuGlobal() {
-    implicit val timeout = Timeout(1 seconds)
+    implicit val timeout = Timeout(5 seconds)
+    val clusterNodes = Cache.getOrElse[scala.collection.mutable.Map[String, ClusterNode]]("clusterNodes")(scala.collection.mutable.Map())
     // Initialize host map
     Cache.set("web.hostmap", collection.mutable.Map[String, ActorRef]())
-    val clusterNodes = Cache.getOrElse[scala.collection.mutable.Map[String, ClusterNode]]("clusterNodes")(scala.collection.mutable.Map())
 
     // Set other config directives
-    Cache.set("web.url", Play.current.configuration.getString("tuktu.url").getOrElse("http://localhost:9000/"))
-    Cache.set("web.jsurl", Play.current.configuration.getString("tuktu.jsurl").getOrElse("Tuktu.js"))
-    Cache.set("web.jsname", Play.current.configuration.getString("tuktu.jsname").getOrElse("tuktu_js_field"))
-    Cache.set("web.repo", Play.current.configuration.getString("tuktu.webrepo").getOrElse("configs/analytics"))
-    Cache.set("web.set_cookies", Play.current.configuration.getBoolean("tuktu.web.set_id_cookies").getOrElse(true))
-    
-    /**
-     * Load this on startup. The application is given as parameter
-     */
-    override def onStart(app: Application) = {
-        // Get the web analytics configs
-        val webRepo = Cache.getAs[String]("web.repo").getOrElse(Play.current.configuration.getString("tuktu.webrepo").getOrElse("configs/analytics"))
-        if (new File(webRepo).exists) {
-            val hostFolders = new File(webRepo).listFiles
-            // These should all be folders that in turn contain a Tuktu.js file in them
-            val futures = for (fldr <- hostFolders) yield {
-                val tuktuJsName = fldr.getAbsolutePath + "/Tuktu.json"
-                // Sanity checks
-                if (fldr.isDirectory) {
-                    // See if the Tuktu.js file is there
-                    try {
-                        val tuktuJsFile = new File(tuktuJsName)
-                        if (tuktuJsFile.exists) {
-                            // Boot up the generator
-                            (fldr.getName, Akka.system.actorSelection("user/TuktuDispatcher") ?
-                                new DispatchRequest(
-                                        webRepo.drop(Play.current.configuration.getString("tuktu.configrepo").getOrElse("configs").size) + "/" + fldr.getName + "/Tuktu",
-                                        None, false, true, false, None))
-                            
-                        } else ("", Future { }) 
-                    } catch {
-                        case e: Exception => { ("", Future { }) }
-                    }
-                } else ("", Future { })
-            }
-        
-            // We must await, otherwise map will not be populated properly
-            try {
-                val result = Await.result(Future.sequence(futures.map(elem => elem._2).toList), timeout.duration).asInstanceOf[List[ActorRef]]
-                futures.map(_._1).zip(result).foreach(elem => 
-                    Cache.getAs[collection.mutable.Map[String, ActorRef]]("web.hostmap").getOrElse(collection.mutable.Map[String, ActorRef]()) += elem._1 -> elem._2
-                )
-            }
-            catch {
-                case e: TimeoutException => {
-                    Logger.warn("Failed to load web analytics config(s).")
-                }
-            }
-        }
-    }
+    Cache.set("web.url", current.configuration.getString("tuktu.url").getOrElse("http://localhost:9000"))
+    Cache.set("web.jsname", current.configuration.getString("tuktu.jsname").getOrElse("tuktu_js_field"))
+    Cache.set("web.repo", current.configuration.getString("tuktu.webrepo").getOrElse("configs/analytics"))
+    Cache.set("web.set_cookies", current.configuration.getBoolean("tuktu.web.set_id_cookies").getOrElse(true))
 }

--- a/modules/web/app/views/Tuktu.scala.js
+++ b/modules/web/app/views/Tuktu.scala.js
@@ -17,9 +17,9 @@ function tuktuFlow(nf) {
 	var s = document.createElement("script");
 	s.setAttribute("type", "text/javascript");
 	s.innerHTML = "var xhr = new XMLHttpRequest();" +
-		"xhr.open('POST', '@jsUrl', true);" +
+		"xhr.open('POST', '@jsUrl/../" + nf + ".js', true);" +
 		"xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');" +
-		"xhr.send(JSON.stringify({f: '" + nf + "', d: tuktuvars}));" +
+		"xhr.send(JSON.stringify({d: tuktuvars}));" +
 		"xhr.onreadystatechange = function() {" +
 			"if (xhr.readyState == 4) {" +
 				"var se = document.createElement('script');" +

--- a/modules/web/conf/web.routes
+++ b/modules/web/conf/web.routes
@@ -1,0 +1,7 @@
+# Routes
+# This file defines all application routes (Higher priority routes first)
+# ~~~~
+
+GET    /*id.js    controllers.web.Application.TuktuJsGet(id)
+POST   /*id.js    controllers.web.Application.TuktuJsPost(id)
+GET    /*id.gif   controllers.web.Application.imgGet(id)


### PR DESCRIPTION
- Redid routing: now support any path in analytics folder, even top-level, as /web/*path/filename.js, so for example /web/Tuktu.js for Tuktu.json in top-level analytics folder, or /web/localhost/ShowPageViews.js for localhost/ShowPageViews.json. flow_name parameters of collector processors remain the same relative paths to the current flow as before (still without .json extension)
- No more autostart, also not from dependent flows; make sure dependent flows are running up-front
- Dispatcher now makes sure the Mailbox is in the hostmap, and not just one of the instances, and also makes sure the Mailbox is removed from the hostmap once it terminates
- Significantly simplified web.Application request handling
- Always user proper paths in showConfigs