### PR TITLE
Provides an empty string for missing keys

### DIFF
--- a/modules/csv/app/tuktu/csv/processors/CsvProcessors.scala
+++ b/modules/csv/app/tuktu/csv/processors/CsvProcessors.scala
@@ -154,16 +154,20 @@ class CSVWriterProcessor(resultName: String) extends BaseProcessor(resultName) {
                 writers(evaluated_fileName).writeNext(headers(evaluated_fileName))
             }
 
-            val values = headers(evaluated_fileName).map(header =>
-                // JsStrings are a bit annoying here, because toString includes surrounding quotes "" for them
-                if (datum(header).isInstanceOf[JsString])
-                    datum(header).asInstanceOf[JsString].value
-                else
-                    datum(header).toString)
-
+            val values = headers(evaluated_fileName).map(header => {
+                datum.get(header) match {
+                    case None => ""
+                    case Some(any) => {
+                        // JsStrings are a bit annoying here, because toString includes surrounding quotes "" for them
+                        if (any.isInstanceOf[JsString])
+                            any.asInstanceOf[JsString].value
+                        else
+                            any.toString
+                    }
+                }
+            })
             writers(evaluated_fileName).writeNext(values)
         }
-
         Future { data }
     }) compose Enumeratee.onEOF(() => {
         for (writer <- writers) {


### PR DESCRIPTION
When a key is missing in a data packet during the generation of a CSV file, a java.util.NoSuchElementException (key not found) is raised, which interrupts the file generation.
The proposed change provides an empty string for missing keys, which allows the CSV file generation to complete.